### PR TITLE
Redesign influencer dashboard layout

### DIFF
--- a/public/influencer.html
+++ b/public/influencer.html
@@ -3,78 +3,52 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Painel Influenciadora | HidraPink</title>
-    <link rel="stylesheet" href="style.css" />
+    <title>Painel da Influenciadora | HidraPink</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="style.css" />
     <script defer src="main.js"></script>
   </head>
   <body data-page="influencer" class="pinklover-body">
-    <div class="pinklover-container" id="influencerPage">
-      <header class="pinklover-hero">
-        <div class="hero-overlay"></div>
-        <div class="hero-content">
-          <div class="hero-intro">
-            <span class="hero-badge">Painel da Pinklover</span>
-            <h1 class="hero-title">Bem-vinda ao universo HidraPink</h1>
-            <p class="hero-subtitle">
-              Acompanhe seu desempenho, comiss�es e hist�rico de vendas com uma vis�o clara e acolhedora.
-            </p>
-          </div>
-          <div class="hero-actions">
-            <button type="button" data-action="logout" class="hero-logout">Sair do painel</button>
-          </div>
-        </div>
-      </header>
+    <main id="influencerPage" class="influencer-layout" aria-live="polite">
+      <section class="quadrant quadrant-welcome">
+        <h1>Bem vinda, Pinklover.</h1>
+      </section>
 
-      <main class="pinklover-main" aria-live="polite">
-        <section class="pinklover-card profile-card">
-          <h1 class="hero-title">Bem-vinda, Pinklover!</h1>
-          <p class="hero-subtitle">Acompanhe seus resultados.</p>
-          <button type="button" data-action="logout" class="hero-logout">Sair do painel</button>
+      <section class="quadrant quadrant-details" aria-labelledby="detailsTitle">
+        <div class="quadrant-header">
+          <h2 id="detailsTitle">Dados principais</h2>
+          <button type="button" data-action="logout" class="logout-button">
+            Sair do painel
+          </button>
         </div>
-      </header>
-      <main class="pinklover-main">
-        <section class="card pinklover-card">
-          <div class="card-header">
-            <div class="card-heading">
-              <h2>Dados da influenciadora</h2>
-              <p class="card-description">Informacoes pessoais, contatos e dados para acompanhar o seu trabalho.</p>
-            </div>
-            <span class="badge">Perfil atualizado</span>
-          </div>
-          <div id="influencerMessage" class="message" aria-live="polite"></div>
-          <div id="influencerDetails" class="details"></div>
-        </section>
+        <div id="influencerMessage" class="message" aria-live="polite"></div>
+        <div id="influencerDetails" class="details"></div>
+      </section>
 
-        <section class="pinklover-card sales-card">
-        <section class="card pinklover-card">
-          <div class="card-header">
-            <div class="card-heading">
-              <h2>Hist�rico de vendas</h2>
-              <p class="card-description">Visualize cada venda, descontos aplicados e o que voc� recebeu de comiss�o.</p>
-            </div>
-            <span class="badge badge-soft">Performance</span>
-          </div>
-          <div id="influencerSalesMessage" class="message" aria-live="polite"></div>
-          <div id="influencerSalesSummary" class="summary summary-highlight"></div>
-          <div class="table-wrapper">
-            <table id="influencerSalesTable" class="pinklover-table">
-              <thead>
-                <tr>
-                  <th>Data</th>
-                  <th>Bruto</th>
-                  <th>Desconto</th>
-                  <th>Liquido</th>
-                  <th>Comissão</th>
-                </tr>
-              </thead>
-              <tbody></tbody>
-            </table>
-          </div>
-        </section>
-      </main>
-    </div>
+      <section class="quadrant quadrant-sales" aria-labelledby="salesTitle">
+        <h2 id="salesTitle">Histórico de vendas</h2>
+        <div id="influencerSalesMessage" class="message" aria-live="polite"></div>
+        <div id="influencerSalesSummary" class="summary"></div>
+        <div class="table-wrapper">
+          <table id="influencerSalesTable" class="sales-table">
+            <thead>
+              <tr>
+                <th scope="col">Data</th>
+                <th scope="col">Bruto</th>
+                <th scope="col">Desconto</th>
+                <th scope="col">Líquido</th>
+                <th scope="col">Comissão</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
   </body>
 </html>

--- a/public/main.js
+++ b/public/main.js
@@ -1294,6 +1294,18 @@
       return;
     }
 
+    const hasContent = (value) => {
+      if (value == null) return false;
+      if (typeof value === 'object') {
+        if (value.type === 'copy-link') {
+          return Boolean(value.url);
+        }
+        return true;
+      }
+      const normalized = String(value).trim();
+      return normalized !== '' && normalized !== '-';
+    };
+
     const createCopyLinkElement = (value) => {
       const wrapper = document.createElement('span');
       wrapper.className = 'detail-value detail-value-with-action';
@@ -1349,30 +1361,58 @@
       return el;
     };
 
+    const highlightFields = [
+      ['Nome', data.nome],
+      ['Cupom', data.cupom],
+      [
+        'Link',
+        data.discountLink
+          ? { type: 'copy-link', url: data.discountLink, label: data.discountLink, copyLabel: 'Copiar link' }
+          : '-'
+      ]
+    ];
+
+    const highlightWrapper = document.createElement('div');
+    highlightWrapper.className = 'details-highlight';
+
+    highlightFields.forEach(([label, value]) => {
+      const row = document.createElement('p');
+      row.className = 'detail-row highlight-row';
+
+      const labelEl = document.createElement('strong');
+      labelEl.className = 'detail-label';
+      labelEl.textContent = label;
+      row.appendChild(labelEl);
+
+      const valueEl = createValueElement(value);
+      row.appendChild(valueEl);
+
+      highlightWrapper.appendChild(row);
+    });
+
+    container.appendChild(highlightWrapper);
+
     const groups = [
       {
-        title: 'Identidade',
+        title: 'Contato',
         items: [
-          ['Nome', data.nome],
           ['Instagram', data.instagram],
           ['Email', data.email],
-          ['Contato', data.contato]
+          ['Telefone', data.contato]
         ]
       },
       {
-        title: 'Performance',
+        title: 'Desempenho',
         items: [
-          ['Cupom', data.cupom],
-          ['Comissao (%)', data.commissionPercent],
-          ['Link compartilhavel', data.discountLink ? { type: 'copy-link', url: data.discountLink, label: data.discountLink, copyLabel: 'Copiar link' } : '-']
+          ['Comissão (%)', data.commissionPercent]
         ]
       },
       {
-        title: 'Endereco',
+        title: 'Endereço',
         items: [
           ['CEP', data.cep],
           ['Logradouro', data.logradouro],
-          ['Numero', data.numero],
+          ['Número', data.numero],
           ['Complemento', data.complemento],
           ['Bairro', data.bairro],
           ['Cidade', data.cidade],
@@ -1385,7 +1425,21 @@
           ['Login', data.loginEmail]
         ]
       }
-    ];
+    ]
+      .map((group) => ({
+        title: group.title,
+        items: group.items.filter(([, value]) => hasContent(value))
+      }))
+      .filter((group) => group.items.length > 0);
+
+    if (!groups.length) return;
+
+    const detailsElement = document.createElement('details');
+    detailsElement.className = 'additional-details';
+
+    const summary = document.createElement('summary');
+    summary.textContent = 'Ver dados completos';
+    detailsElement.appendChild(summary);
 
     const grid = document.createElement('div');
     grid.className = 'details-grid';
@@ -1404,6 +1458,7 @@
       group.items.forEach(([label, value]) => {
         const row = document.createElement('p');
         row.className = 'detail-row';
+
         const labelEl = document.createElement('strong');
         labelEl.className = 'detail-label';
         labelEl.textContent = label;
@@ -1418,7 +1473,8 @@
       grid.appendChild(card);
     });
 
-    container.appendChild(grid);
+    detailsElement.appendChild(grid);
+    container.appendChild(detailsElement);
   };
 
   const initInfluencerPage = () => {

--- a/public/style.css
+++ b/public/style.css
@@ -662,13 +662,357 @@ body[data-page="master"] .button-row {
 }
 .pinklover-body {
   font-family: 'Poppins', sans-serif;
-  background: radial-gradient(circle at 20% 20%, #fbd3db 0%, rgba(251, 211, 219, 0) 45%),
-              radial-gradient(circle at 80% 0%, rgba(240, 121, 153, 0.3), rgba(240, 121, 153, 0) 55%),
-              radial-gradient(circle at 50% 100%, rgba(228, 68, 122, 0.4), rgba(15, 15, 40, 0) 60%),
-              #0b0d1b;
+  background: linear-gradient(180deg, #ffe6f2 0%, #ffd4e6 45%, #ffc7df 100%);
   min-height: 100vh;
-  color: #1b1b2f;
+  color: #3a1030;
   margin: 0;
+  display: flex;
+  justify-content: center;
+  padding: 48px 0;
+}
+
+.influencer-layout {
+  width: min(960px, 100%);
+  margin: 0 auto;
+  display: grid;
+  gap: clamp(20px, 5vw, 32px);
+  padding: 0 clamp(16px, 6vw, 48px);
+}
+
+.quadrant {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.75), rgba(255, 255, 255, 0.55))
+      padding-box,
+    linear-gradient(135deg, rgba(255, 255, 255, 0.6), rgba(255, 182, 209, 0.8)) border-box;
+  border-radius: 26px;
+  border: 1px solid transparent;
+  box-shadow: 0 24px 50px rgba(236, 72, 153, 0.25);
+  backdrop-filter: blur(6px);
+  padding: clamp(28px, 6vw, 40px);
+  display: grid;
+  gap: clamp(16px, 3vw, 24px);
+}
+
+.quadrant-welcome {
+  text-align: center;
+  background: radial-gradient(circle at 20% -10%, rgba(255, 255, 255, 0.9), rgba(255, 213, 228, 0.65))
+      padding-box,
+    linear-gradient(135deg, rgba(245, 112, 157, 0.65), rgba(236, 72, 153, 0.9)) border-box;
+  color: #4c0b2f;
+}
+
+.quadrant-welcome h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 2.8rem);
+  font-weight: 700;
+}
+
+.quadrant-details,
+.quadrant-sales {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(255, 201, 221, 0.88)) padding-box,
+    linear-gradient(135deg, rgba(236, 72, 153, 0.3), rgba(236, 72, 153, 0.65)) border-box;
+}
+
+.quadrant-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.quadrant h2 {
+  margin: 0;
+  font-size: clamp(1.3rem, 3vw, 1.6rem);
+  font-weight: 600;
+  color: #4c0b2f;
+}
+
+.logout-button {
+  border: none;
+  background: rgba(236, 72, 153, 0.85);
+  color: #fff;
+  border-radius: 999px;
+  padding: 10px 22px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  cursor: pointer;
+  box-shadow: 0 18px 28px rgba(236, 72, 153, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.logout-button:hover,
+.logout-button:focus {
+  outline: none;
+  transform: translateY(-1px);
+  box-shadow: 0 20px 32px rgba(236, 72, 153, 0.45);
+}
+
+.quadrant .message {
+  min-height: 48px;
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 16px;
+  padding: 12px 18px;
+  font-weight: 500;
+  color: #4c0b2f;
+  border: 1px solid rgba(236, 72, 153, 0.25);
+}
+
+.quadrant .message[data-type='success'] {
+  background: rgba(72, 187, 120, 0.18);
+  border-color: rgba(56, 161, 105, 0.4);
+  color: #1d4f3b;
+}
+
+.quadrant .message[data-type='error'] {
+  background: rgba(244, 63, 94, 0.18);
+  border-color: rgba(225, 29, 72, 0.4);
+  color: #7f142f;
+}
+
+.quadrant .message[data-type='info'] {
+  background: rgba(59, 130, 246, 0.16);
+  border-color: rgba(59, 130, 246, 0.35);
+  color: #1e3a8a;
+}
+
+.quadrant-details .details {
+  display: grid;
+  gap: 14px;
+}
+
+.quadrant-details .details-highlight {
+  display: grid;
+  gap: 12px;
+}
+
+.quadrant-details .highlight-row {
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 16px;
+  padding: 14px 18px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 14px;
+  box-shadow: inset 0 0 0 1px rgba(236, 72, 153, 0.12);
+}
+
+.quadrant-details .detail-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 1rem;
+  color: #4c0b2f;
+}
+
+.quadrant-details .detail-label {
+  font-weight: 600;
+  letter-spacing: 0.2px;
+}
+
+.quadrant-details .detail-label::after {
+  content: ':';
+  margin-left: 4px;
+  font-weight: 500;
+}
+
+.quadrant-details .detail-value {
+  font-weight: 600;
+  color: #4c0b2f;
+}
+
+.quadrant-details .detail-value-with-action {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.quadrant-details .detail-link {
+  color: #a81863;
+  text-decoration: none;
+}
+
+.quadrant-details .detail-link:hover,
+.quadrant-details .detail-link:focus {
+  text-decoration: underline;
+}
+
+.quadrant-details .copy-button {
+  border: none;
+  background: rgba(236, 72, 153, 0.16);
+  color: #a81863;
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 8px 16px rgba(236, 72, 153, 0.2);
+}
+
+.quadrant-details .copy-button:hover,
+.quadrant-details .copy-button:focus {
+  outline: none;
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(236, 72, 153, 0.24);
+}
+
+.quadrant-details .copy-button.copied {
+  background: rgba(74, 222, 128, 0.28);
+  color: #166534;
+}
+
+.quadrant-details .copy-button.error {
+  background: rgba(248, 113, 113, 0.28);
+  color: #7f1d1d;
+}
+
+.additional-details {
+  margin-top: 12px;
+  padding-top: 18px;
+  border-top: 1px solid rgba(236, 72, 153, 0.25);
+}
+
+.additional-details summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: #4c0b2f;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  list-style: none;
+  position: relative;
+  padding-right: 28px;
+  margin-bottom: 12px;
+}
+
+.additional-details summary::marker {
+  display: none;
+}
+
+.additional-details summary::after {
+  content: '+';
+  font-weight: 700;
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.additional-details[open] summary::after {
+  content: '–';
+}
+
+.quadrant-details .details-grid {
+  display: grid;
+  gap: 18px;
+  margin-top: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.quadrant-details .detail-card {
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(236, 72, 153, 0.25);
+  border-radius: 18px;
+  padding: 18px 20px;
+  color: #4c0b2f;
+  box-shadow: 0 16px 28px rgba(236, 72, 153, 0.18);
+}
+
+.quadrant-details .detail-card-title {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(76, 11, 47, 0.7);
+  margin: 0 0 12px;
+}
+
+.quadrant-details .detail-card .detail-row {
+  padding: 6px 0;
+  border-bottom: 1px dashed rgba(236, 72, 153, 0.2);
+}
+
+.quadrant-details .detail-card .detail-row:last-of-type {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.quadrant-sales .summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-weight: 600;
+  color: #4c0b2f;
+}
+
+.quadrant-sales .summary span {
+  background: rgba(255, 255, 255, 0.65);
+  border-radius: 999px;
+  padding: 6px 16px;
+}
+
+.quadrant-sales .table-wrapper {
+  border-radius: 18px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.65);
+}
+
+.quadrant-sales table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.quadrant-sales th,
+.quadrant-sales td {
+  padding: 12px 16px;
+  text-align: left;
+  color: #421029;
+  border-bottom: 1px solid rgba(236, 72, 153, 0.15);
+}
+
+.quadrant-sales thead {
+  background: rgba(236, 72, 153, 0.12);
+}
+
+.quadrant-sales thead th {
+  font-weight: 600;
+  color: #4c0b2f;
+}
+
+.quadrant-sales tbody tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.75);
+}
+
+.quadrant-sales tbody tr:hover {
+  background: rgba(236, 72, 153, 0.08);
+}
+
+.quadrant-sales .empty {
+  padding: 18px;
+  text-align: center;
+  font-style: italic;
+  color: rgba(76, 11, 47, 0.7);
+}
+
+@media (max-width: 720px) {
+  .pinklover-body {
+    padding: 32px 0;
+  }
+
+  .quadrant {
+    padding: clamp(24px, 8vw, 32px);
+  }
+
+  .quadrant-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .logout-button {
+    width: 100%;
+    text-align: center;
+  }
 }
 
 .pinklover-container {


### PR DESCRIPTION
## Summary
- rebuild the influencer panel into three stacked quadrants for welcome, key data, and sales history
- refresh the influencer stylesheet with a pink gradient background and quadrant-specific styling, including highlight cards and responsive tweaks
- adjust influencer detail rendering logic to show key fields prominently and provide expandable access to the remaining information

## Testing
- No automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e546a5ea688323a76eb0e93dcec582