### PR TITLE
Add order code support and import confirmation flow

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,8 +5,57 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sistema Influenciadoras</title>
     <meta http-equiv="refresh" content="0;url=login.html" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --pink-strong: #e4447a;
+        --pink-medium: #f07999;
+        --pink-light: #fbd3db;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+        font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: #fff;
+        background-image: radial-gradient(circle at top right, rgba(228, 68, 122, 0.15), transparent 58%),
+          radial-gradient(circle at bottom left, rgba(240, 121, 153, 0.2), transparent 60%),
+          linear-gradient(180deg, rgba(251, 211, 219, 0.28), rgba(255, 255, 255, 0.45));
+        color: var(--pink-strong);
+      }
+
+      .redirect-card {
+        background: rgba(255, 255, 255, 0.92);
+        padding: 24px 32px;
+        border-radius: 24px;
+        text-align: center;
+        box-shadow: 0 18px 40px rgba(228, 68, 122, 0.18);
+        border: 1px solid rgba(228, 68, 122, 0.28);
+      }
+
+      .redirect-card a {
+        color: var(--pink-medium);
+        font-weight: 600;
+        text-decoration: none;
+      }
+    </style>
   </head>
   <body>
-    <p>Redirecionando para <a href="login.html">login</a>...</p>
+    <div class="redirect-card">
+      <p>Redirecionando para <a href="login.html">login</a>...</p>
+    </div>
   </body>
 </html>

--- a/public/influencer.html
+++ b/public/influencer.html
@@ -4,54 +4,364 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Painel Influenciadora | HidraPink</title>
-    <link rel="stylesheet" href="style.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <script defer src="main.js"></script>
+    <style>
+      :root {
+        --pink-strong: #e4447a;
+        --pink-medium: #f07999;
+        --pink-light: #fbd3db;
+        --text-color: #361725;
+        --shadow: 0 26px 60px rgba(228, 68, 122, 0.22);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: 'Montserrat', sans-serif;
+        background: #fff;
+        background-image: radial-gradient(circle at top right, rgba(228, 68, 122, 0.14), transparent 60%),
+          radial-gradient(circle at bottom left, rgba(240, 121, 153, 0.18), transparent 58%),
+          linear-gradient(180deg, rgba(251, 211, 219, 0.28), rgba(255, 255, 255, 0.4));
+        color: var(--text-color);
+        display: flex;
+        justify-content: center;
+        align-items: flex-start;
+        padding: 48px 16px 56px;
+      }
+
+      .pinklover-container {
+        width: 100%;
+        max-width: 600px;
+        display: flex;
+        flex-direction: column;
+        gap: 36px;
+      }
+
+      .pinklover-content {
+        display: flex;
+        flex-direction: column;
+        gap: 32px;
+      }
+
+      .pinklover-banner {
+        background: linear-gradient(115deg, var(--pink-strong), var(--pink-medium));
+        color: #ffffff;
+        text-align: center;
+        font-weight: 700;
+        font-size: 1.5rem;
+        padding: 18px 24px;
+        border-radius: 22px;
+        box-shadow: var(--shadow);
+        margin: 0;
+        letter-spacing: 0.02em;
+      }
+
+      .card {
+        background: linear-gradient(135deg, var(--pink-strong), var(--pink-medium));
+        border-radius: 26px;
+        padding: 28px 28px 32px;
+        box-shadow: var(--shadow);
+        color: var(--text-color);
+        position: relative;
+        overflow: hidden;
+        z-index: 0;
+      }
+
+      .card::before {
+        content: '';
+        position: absolute;
+        inset: 1px;
+        border-radius: 24px;
+        border: 1px solid rgba(255, 255, 255, 0.32);
+        pointer-events: none;
+        z-index: 0;
+      }
+
+      .card > * {
+        position: relative;
+        z-index: 1;
+      }
+
+      .card h2 {
+        margin: 0 0 18px;
+        font-size: 1.25rem;
+        font-weight: 700;
+        text-align: center;
+      }
+
+      .logout-wrapper {
+        display: flex;
+        justify-content: flex-end;
+        margin-top: 8px;
+      }
+
+      .logout-button {
+        margin: 0;
+        background: #ffffff;
+        color: var(--pink-strong);
+        border: none;
+        border-radius: 999px;
+        padding: 12px 28px;
+        font-weight: 700;
+        font-size: 0.95rem;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+        box-shadow: 0 12px 24px rgba(255, 255, 255, 0.25);
+      }
+
+      .logout-button:hover,
+      .logout-button:focus {
+        transform: translateY(-1px);
+        box-shadow: 0 16px 30px rgba(255, 255, 255, 0.35);
+        outline: none;
+      }
+
+      .influencer-info {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .info-item {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 6px;
+      }
+
+      .info-label {
+        font-weight: 700;
+        font-size: 0.95rem;
+      }
+
+      .info-value {
+        font-weight: 500;
+        font-size: 1rem;
+        word-break: break-word;
+      }
+
+      .detail-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .copy-button {
+        background: rgba(255, 255, 255, 0.28);
+        color: var(--text-color);
+        border: none;
+        border-radius: 999px;
+        padding: 8px 16px;
+        font-weight: 600;
+        font-size: 0.85rem;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .copy-button:hover,
+      .copy-button:focus {
+        transform: translateY(-1px);
+        box-shadow: 0 6px 18px rgba(45, 13, 27, 0.15);
+        outline: none;
+      }
+
+      .copy-button.copied {
+        background: rgba(255, 255, 255, 0.48);
+      }
+
+      .copy-button.error {
+        background: rgba(255, 255, 255, 0.22);
+      }
+
+      .influencer-message {
+        margin-top: 16px;
+        font-size: 0.95rem;
+        text-align: center;
+      }
+
+      .sales-header {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        margin-bottom: 18px;
+      }
+
+      .table-wrapper {
+        overflow-x: auto;
+        background: rgba(255, 255, 255, 0.38);
+        border-radius: 20px;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.95rem;
+        min-width: 460px;
+      }
+
+      th,
+      td {
+        padding: 14px 16px;
+        text-align: left;
+      }
+
+      th {
+        font-weight: 700;
+        text-transform: uppercase;
+        font-size: 0.8rem;
+        letter-spacing: 0.05em;
+        color: var(--text-color);
+        background: rgba(255, 255, 255, 0.7);
+      }
+
+      tbody tr:nth-child(odd) {
+        background: rgba(251, 211, 219, 0.45);
+      }
+
+      tbody tr:nth-child(even) {
+        background: rgba(255, 255, 255, 0.9);
+      }
+
+      tbody tr:hover {
+        background: rgba(240, 121, 153, 0.2);
+      }
+
+      td {
+        font-weight: 500;
+      }
+
+      td.empty {
+        text-align: center;
+        font-weight: 600;
+        padding: 24px 16px;
+      }
+
+      .sales-message,
+      .influencer-message {
+        margin: 16px 0 0;
+        text-align: center;
+        font-weight: 500;
+      }
+
+      .sales-message:empty,
+      .influencer-message:empty {
+        display: none;
+        margin: 0;
+      }
+
+      .influencer-message[data-type='success'],
+      .sales-message[data-type='success'] {
+        color: #0f5132;
+      }
+
+      .influencer-message[data-type='error'],
+      .sales-message[data-type='error'] {
+        color: #7a1634;
+      }
+
+      .influencer-message[data-type='info'],
+      .sales-message[data-type='info'] {
+        color: var(--text-color);
+        opacity: 0.85;
+      }
+
+      .summary {
+        margin-top: 20px;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        text-align: center;
+        font-weight: 600;
+      }
+
+      .summary span {
+        display: block;
+        padding: 10px 18px;
+        border-radius: 999px;
+        background: rgba(251, 211, 219, 0.55);
+      }
+
+      a.detail-link {
+        color: inherit;
+        font-weight: 600;
+        text-decoration: underline;
+      }
+
+      @media (max-width: 768px) {
+        body {
+          padding: 40px 16px 48px;
+        }
+
+        .pinklover-container {
+          gap: 30px;
+        }
+      }
+
+      @media (max-width: 480px) {
+        body {
+          padding: 32px 12px 40px;
+        }
+
+        .pinklover-content {
+          gap: 26px;
+        }
+
+        .card {
+          padding: 22px 20px 26px;
+        }
+
+        table {
+          min-width: 320px;
+        }
+      }
+    </style>
   </head>
-  <body data-page="influencer" class="pinklover-body">
+  <body data-page="influencer">
     <div class="pinklover-container" id="influencerPage">
-      <header class="pinklover-hero">
-        <div class="hero-overlay"></div>
-        <div class="hero-content">
-          <h1 class="hero-title">Bem-vinda, Pinklover!</h1>
-          <p class="hero-subtitle">Acompanhe seus resultados.</p>
-          <button type="button" data-action="logout" class="hero-logout">Sair do painel</button>
-        </div>
-      </header>
-      <main class="pinklover-main">
-        <section class="card pinklover-card">
-          <div class="card-header">
-            <h2>Meus dados</h2>
-            <span class="badge">Perfil atualizado</span>
-          </div>
-          <div id="influencerDetails" class="details"></div>
-          <div id="influencerMessage" class="message" aria-live="polite"></div>
+      <header class="pinklover-banner">Bem vinda, Pinklover.</header>
+
+      <main class="pinklover-content">
+        <section class="card" aria-labelledby="influencer-info-title">
+          <h2 id="influencer-info-title">Suas informações</h2>
+          <div id="influencerDetails" class="influencer-info"></div>
+          <div id="influencerMessage" class="influencer-message" aria-live="polite"></div>
         </section>
-        <section class="card pinklover-card">
-          <div class="card-header">
-            <h2>Minhas vendas</h2>
-            <span class="badge badge-soft">Performance</span>
+
+        <section class="card" aria-labelledby="influencer-sales-title">
+          <div class="sales-header">
+            <h2 id="influencer-sales-title">Acompanhe seu desempenho.</h2>
           </div>
-          <div id="influencerSalesMessage" class="message" aria-live="polite"></div>
+          <div id="influencerSalesMessage" class="sales-message" aria-live="polite"></div>
           <div class="table-wrapper">
-            <table id="influencerSalesTable" class="pinklover-table">
+            <table id="influencerSalesTable">
               <thead>
                 <tr>
                   <th>Data</th>
-                  <th>Bruto</th>
-                  <th>Desconto</th>
-                  <th>Liquido</th>
-                  <th>Comissão</th>
+                  <th>Cliente</th>
+                  <th>Valor</th>
+                  <th>Status</th>
                 </tr>
               </thead>
               <tbody></tbody>
             </table>
           </div>
-          <div id="influencerSalesSummary" class="summary summary-highlight"></div>
+          <div id="influencerSalesSummary" class="summary"></div>
         </section>
       </main>
+
+      <div class="logout-wrapper">
+        <button type="button" data-action="logout" class="logout-button">Sair do painel</button>
+      </div>
     </div>
   </body>
 </html>

--- a/public/main.js
+++ b/public/main.js
@@ -990,6 +990,7 @@
     const form = document.getElementById('createSaleForm');
     const messageEl = document.getElementById('salesMessage');
     const saleCouponSelect = document.getElementById('saleCouponSelect');
+    const saleOrderInput = form?.elements.orderCode || form?.elements.order_code || null;
     const saleDateInput = form?.elements.saleDate || null;
     const saleGrossInput = form?.elements.grossValue || null;
     const saleDiscountInput = form?.elements.discountValue || null;
@@ -999,13 +1000,887 @@
     const reloadSalesButton = document.getElementById('reloadSalesButton');
     const salesTableBody = document.querySelector('#salesTable tbody');
     const salesSummaryEl = document.getElementById('salesSummary');
+    const importSalesForm = document.getElementById('importSalesForm');
+    const importSalesFileInput = document.getElementById('importSalesFile');
+    const importSalesTextInput = document.getElementById('importSalesText');
+    const importMessageEl = document.getElementById('importSalesMessage');
+    const clearImportButton = document.getElementById('clearImportButton');
+    const importPreviewWrapper = document.getElementById('importPreview');
+    const importPreviewTableBody = document.querySelector('#importPreviewTable tbody');
+    const importSummaryEl = document.getElementById('importSummary');
+    const importActionButtons = document.getElementById('importActionButtons');
+    const saveImportButton = document.getElementById('saveImportButton');
+    const cancelImportButton = document.getElementById('cancelImportButton');
 
     addRealtimeValidation(form);
+    addRealtimeValidation(importSalesForm);
 
     let influencers = [];
     let sales = [];
     let currentSalesInfluencerId = null;
     let saleEditingId = null;
+    let pendingImportEntries = [];
+
+    const showElement = (element) => {
+      element?.classList?.remove('hidden');
+    };
+
+    const hideElement = (element) => {
+      element?.classList?.add('hidden');
+    };
+
+    const readFileAsText = (file) => {
+      if (!file) return Promise.resolve('');
+      if (typeof file.text === 'function') {
+        return file.text();
+      }
+      return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result || '');
+        reader.onerror = () => reject(reader.error || new Error('Falha ao ler o arquivo.'));
+        reader.readAsText(file);
+      });
+    };
+
+    const getNestedValue = (object, path) => {
+      if (!object || typeof object !== 'object') return undefined;
+      const parts = String(path)
+        .split('.')
+        .map((part) => part.trim())
+        .filter(Boolean);
+      if (!parts.length) return undefined;
+      let value = object;
+      for (const part of parts) {
+        if (value && typeof value === 'object' && part in value) {
+          value = value[part];
+        } else {
+          return undefined;
+        }
+      }
+      return value;
+    };
+
+    const findValueByKeys = (object, keys = []) => {
+      if (!object || typeof object !== 'object') return undefined;
+      for (const key of keys) {
+        if (!key) continue;
+        const value = key.includes('.') ? getNestedValue(object, key) : object[key];
+        if (value !== undefined && value !== null) {
+          return value;
+        }
+      }
+      return undefined;
+    };
+
+    const parseNumeric = (value) => {
+      if (value == null || value === '') return null;
+      if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : null;
+      }
+      if (typeof value === 'boolean') {
+        return value ? 1 : 0;
+      }
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (!trimmed) return null;
+        let sanitized = trimmed.replace(/[^0-9.,-]/g, '');
+        if (!sanitized) return null;
+        const lastComma = sanitized.lastIndexOf(',');
+        const lastDot = sanitized.lastIndexOf('.');
+        if (lastComma > lastDot) {
+          sanitized = sanitized.replace(/\./g, '').replace(',', '.');
+        } else if (lastDot > lastComma) {
+          sanitized = sanitized.replace(/,/g, '');
+        } else {
+          sanitized = sanitized.replace(/,/g, '.');
+        }
+        const number = Number(sanitized);
+        return Number.isFinite(number) ? number : null;
+      }
+      const number = Number(value);
+      return Number.isFinite(number) ? number : null;
+    };
+
+    const parseInteger = (value) => {
+      const number = parseNumeric(value);
+      if (!Number.isFinite(number)) return null;
+      return Math.round(number);
+    };
+
+    const normalizeOrderCode = (value) => {
+      if (value == null) return '';
+      const text = String(value).trim();
+      if (!text) return '';
+      return text.toUpperCase();
+    };
+
+    const parseDateFromText = (value) => {
+      if (value == null) return null;
+      const text = String(value).trim();
+      if (!text) return null;
+      const cleaned = text.replace(/[\u00A0\s]+/g, ' ').trim();
+      const isoMatch = cleaned.match(/(\d{4})[\/\.\-](\d{1,2})[\/\.\-](\d{1,2})/);
+      let year;
+      let month;
+      let day;
+      if (isoMatch) {
+        year = Number(isoMatch[1]);
+        month = Number(isoMatch[2]);
+        day = Number(isoMatch[3]);
+      } else {
+        const brMatch = cleaned.match(/(\d{1,2})[\/\.\-](\d{1,2})[\/\.\-](\d{2,4})/);
+        if (!brMatch) return null;
+        day = Number(brMatch[1]);
+        month = Number(brMatch[2]);
+        year = Number(brMatch[3]);
+        if (year < 100) {
+          year += year >= 70 ? 1900 : 2000;
+        }
+      }
+
+      if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return null;
+      const date = new Date(Date.UTC(year, month - 1, day));
+      if (Number.isNaN(date.getTime())) return null;
+      if (date.getUTCFullYear() !== year || date.getUTCMonth() + 1 !== month || date.getUTCDate() !== day) return null;
+      const pad = (num) => String(num).padStart(2, '0');
+      return `${String(year).padStart(4, '0')}-${pad(month)}-${pad(day)}`;
+    };
+
+    const formatDateForDisplay = (value) => {
+      if (!value) return '';
+      const text = String(value).trim();
+      if (!text) return '';
+      if (/^\d{4}-\d{2}-\d{2}$/.test(text)) {
+        const [year, month, day] = text.split('-');
+        return `${day}/${month}/${year}`;
+      }
+      const parsed = parseDateFromText(text);
+      if (parsed) {
+        const [year, month, day] = parsed.split('-');
+        return `${day}/${month}/${year}`;
+      }
+      return text;
+    };
+
+    const normalizeHeaderKey = (value) =>
+      String(value || '')
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '');
+
+    const detectDelimiter = (line) => {
+      if (line.includes('\t')) return '\t';
+      if (line.includes(';')) return ';';
+      if ((line.match(/\|/g) || []).length >= 3) return '|';
+      const commaCount = (line.match(/,/g) || []).length;
+      const dotCount = (line.match(/\./g) || []).length;
+      if (commaCount >= 3 && commaCount > dotCount) return ',';
+      if (/\s{2,}/.test(line)) return /\s{2,}/;
+      return /\s+/;
+    };
+
+    const splitColumns = (line, delimiter) => {
+      if (delimiter === '\t' || typeof delimiter === 'string') {
+        return line.split(delimiter).map((cell) => cell.trim());
+      }
+      if (delimiter instanceof RegExp) {
+        return line.split(delimiter).map((cell) => cell.trim());
+      }
+      return [line.trim()];
+    };
+
+    const parsePastedSalesText = (text) => {
+      if (typeof text !== 'string') return [];
+      const normalizedText = text.replace(/\r\n?/g, '\n').split('\n');
+      const lines = normalizedText.map((line) => line.trim()).filter((line) => line);
+      if (!lines.length) return [];
+
+      let headerLine = lines[0];
+      let delimiter = detectDelimiter(headerLine);
+      let headerCells = splitColumns(headerLine, delimiter);
+      const headerTypes = headerCells.map((cell) => {
+        const key = normalizeHeaderKey(cell);
+        if (!key) return null;
+        if (['name', 'pedido', 'order', 'ordem', 'numero', 'orderid', 'ordercodigo', 'ordercode'].includes(key)) return 'order';
+        if (['paidat', 'data', 'date', 'pagamento', 'paymentdate', 'datapagamento'].includes(key)) return 'date';
+        if (['subtotal', 'valor', 'total', 'amount', 'gross', 'valorbruto', 'totalpedido'].includes(key)) return 'gross';
+        if (['discountcode', 'cupom', 'coupon', 'codigodesconto', 'codigocupom'].includes(key)) return 'coupon';
+        return null;
+      });
+
+      let dataLines = lines.slice(1);
+      let columnTypes = headerTypes;
+
+      if (headerTypes.filter(Boolean).length < 2) {
+        dataLines = lines;
+        headerLine = lines[0];
+        delimiter = detectDelimiter(headerLine);
+        headerCells = splitColumns(headerLine, delimiter);
+        columnTypes = headerCells.map((_, index) => {
+          const defaults = ['order', 'date', 'gross', 'coupon'];
+          return defaults[index] || null;
+        });
+      }
+
+      if (!dataLines.length) return [];
+      if (!columnTypes.length) {
+        delimiter = detectDelimiter(dataLines[0]);
+        const firstRow = splitColumns(dataLines[0], delimiter);
+        columnTypes = firstRow.map((_, index) => {
+          const defaults = ['order', 'date', 'gross', 'coupon'];
+          return defaults[index] || null;
+        });
+      }
+
+      const entries = [];
+      dataLines.forEach((line) => {
+        if (!line) return;
+        const cells = splitColumns(line, delimiter);
+        if (!cells.some((cell) => cell)) return;
+        const entry = {};
+        columnTypes.forEach((type, index) => {
+          if (!type) return;
+          const value = cells[index] ?? '';
+          if (!value && value !== 0) return;
+          if (type === 'order') {
+            entry.order = value;
+            entry.pedido = value;
+            entry.order_id = value;
+          } else if (type === 'date') {
+            entry.paid_at = value;
+            entry.date = value;
+            entry.data = value;
+          } else if (type === 'gross') {
+            entry.subtotal = value;
+            entry.gross_value = value;
+            entry.grossSales = value;
+            entry.gross = value;
+            entry.net_value = value;
+            entry.netSales = value;
+          } else if (type === 'coupon') {
+            entry.cupom = value;
+            entry.coupon = value;
+            entry.discount_code = value;
+            entry.coupon_code = value;
+          }
+        });
+        if (Object.keys(entry).length) {
+          entry.__source = { type: 'paste', rawLine: line };
+          entries.push(entry);
+        }
+      });
+      return entries;
+    };
+
+    const extractArrayFromData = (data) => {
+      if (Array.isArray(data)) return data;
+      if (!data || typeof data !== 'object') return [];
+      const possibleKeys = [
+        'sales',
+        'vendas',
+        'data',
+        'items',
+        'pedidos',
+        'coupons',
+        'relatorio',
+        'relatorio_detalhado',
+        'report',
+        'reports',
+        'resultado',
+        'result',
+        'entries',
+        'rows',
+        'values',
+        'lista'
+      ];
+      for (const key of possibleKeys) {
+        const value = data[key];
+        if (Array.isArray(value)) return value;
+        if (value && typeof value === 'object') {
+          const nested = extractArrayFromData(value);
+          if (nested.length) return nested;
+        }
+      }
+      for (const value of Object.values(data)) {
+        if (Array.isArray(value)) return value;
+        if (value && typeof value === 'object') {
+          const nested = extractArrayFromData(value);
+          if (nested.length) return nested;
+        }
+      }
+      return [];
+    };
+
+    const normalizeImportEntries = (entries = []) => {
+      if (!Array.isArray(entries)) return [];
+      const couponKeys = ['cupom', 'coupon', 'discount_code', 'discountCode', 'code', 'coupon_code', 'couponCode', 'name'];
+      const grossKeys = [
+        'grossSales',
+        'gross_sales',
+        'gross_value',
+        'valor_bruto',
+        'valorBruto',
+        'vendas_brutas',
+        'sales_gross',
+        'amount.gross',
+        'gross'
+      ];
+      const discountKeys = [
+        'discount',
+        'discount_total',
+        'discountAmount',
+        'discount_amount',
+        'valor_desconto',
+        'desconto',
+        'descontos',
+        'amount.discount'
+      ];
+      const netKeys = [
+        'netSales',
+        'net_sales',
+        'net_value',
+        'valor_liquido',
+        'valorLiquido',
+        'vendas_liquidas',
+        'amount.net',
+        'net'
+      ];
+      const ordersKeys = ['orders', 'orders_with_discount', 'ordersWithDiscount', 'pedidos', 'total_orders', 'ordersApplied'];
+      const orderKeys = [
+        'order',
+        'order_id',
+        'orderId',
+        'orderNumber',
+        'pedido',
+        'numero',
+        'pedido_id',
+        'numero_pedido',
+        'orderCode',
+        'ordercode',
+        'name'
+      ];
+      const dateKeys = ['date', 'data', 'paid_at', 'paidAt', 'payment_date', 'datapagamento'];
+
+      return entries.map((entry, index) => {
+        const couponValue = findValueByKeys(entry, couponKeys);
+        const coupon = couponValue != null ? String(couponValue).trim() : '';
+        const influencer = getInfluencerByCoupon(coupon);
+
+        const orderValue = findValueByKeys(entry, orderKeys);
+        const orderCodeRaw = orderValue != null ? String(orderValue).trim() : '';
+        const orderCodeNormalized = normalizeOrderCode(orderCodeRaw || orderValue);
+        const rawDate = findValueByKeys(entry, dateKeys);
+        const parsedDate = parseDateFromText(rawDate);
+
+        let grossValue = parseNumeric(findValueByKeys(entry, grossKeys));
+        let discount = parseNumeric(findValueByKeys(entry, discountKeys));
+        let netValue = parseNumeric(findValueByKeys(entry, netKeys));
+        const orders = parseInteger(findValueByKeys(entry, ordersKeys));
+
+        if (!Number.isFinite(grossValue) && Number.isFinite(netValue) && Number.isFinite(discount)) {
+          grossValue = netValue + discount;
+        }
+
+        if (!Number.isFinite(netValue) && Number.isFinite(grossValue) && Number.isFinite(discount)) {
+          netValue = grossValue - discount;
+        }
+
+        if (!Number.isFinite(discount) && Number.isFinite(grossValue) && Number.isFinite(netValue)) {
+          discount = Math.max(0, grossValue - netValue);
+        }
+
+        if (!Number.isFinite(grossValue) && Number.isFinite(netValue)) {
+          grossValue = netValue + Math.max(0, discount || 0);
+        }
+
+        if (!Number.isFinite(netValue) && Number.isFinite(grossValue)) {
+          netValue = grossValue - Math.max(0, discount || 0);
+        }
+
+        grossValue = Number.isFinite(grossValue) ? Math.max(0, grossValue) : null;
+        discount = Number.isFinite(discount) ? Math.max(0, discount) : 0;
+        netValue = Number.isFinite(netValue) ? Math.max(0, netValue) : null;
+
+        if (grossValue == null && netValue != null) {
+          grossValue = netValue + discount;
+        }
+
+        if (netValue == null && grossValue != null) {
+          netValue = Math.max(0, grossValue - discount);
+        }
+
+        if (!Number.isFinite(netValue)) netValue = null;
+        if (!Number.isFinite(grossValue)) grossValue = null;
+
+        const result = {
+          index: index + 1,
+          entry,
+          cupom: coupon,
+          influencerId: influencer?.id || null,
+          influencerName: influencer?.nome || '',
+          orderCode: orderCodeRaw || orderCodeNormalized,
+          orderCodeNormalized,
+          rawDate: rawDate != null ? String(rawDate).trim() : '',
+          date: parsedDate,
+          grossValue,
+          discount,
+          netValue,
+          orders: Number.isFinite(orders) ? Math.max(0, orders) : null,
+          canImport: Boolean(
+            influencer &&
+              coupon &&
+              grossValue != null &&
+              netValue != null &&
+              parsedDate &&
+              orderCodeNormalized
+          ),
+          status: 'ready',
+          statusMessage: 'Pronto para importação',
+          sourceType: entry?.__source?.type || 'file'
+        };
+
+        if (!coupon) {
+          result.status = 'error';
+          result.statusMessage = 'Cupom ausente no arquivo.';
+          result.canImport = false;
+        } else if (!influencer) {
+          result.status = 'warning';
+          result.statusMessage = 'Cupom não cadastrado no sistema.';
+          result.canImport = false;
+        } else if (!orderCodeNormalized) {
+          result.status = 'error';
+          result.statusMessage = 'Pedido não informado no arquivo.';
+          result.canImport = false;
+        } else if (!parsedDate) {
+          result.status = 'error';
+          result.statusMessage = 'Data da venda não encontrada.';
+          result.canImport = false;
+        } else if (grossValue == null) {
+          result.status = 'error';
+          result.statusMessage = 'Valor bruto não encontrado para o cupom.';
+          result.canImport = false;
+        } else if (netValue == null) {
+          result.status = 'error';
+          result.statusMessage = 'Valor líquido não pôde ser calculado.';
+          result.canImport = false;
+        }
+
+        return result;
+      });
+    };
+
+    const renderImportPreview = (rows = []) => {
+      if (!importPreviewTableBody) return;
+      importPreviewTableBody.innerHTML = '';
+      if (!rows.length) {
+        hideElement(importPreviewWrapper);
+        hideElement(importSummaryEl);
+        hideElement(importActionButtons);
+        return;
+      }
+
+      const fragment = document.createDocumentFragment();
+      rows.forEach((row) => {
+        const tr = document.createElement('tr');
+        tr.dataset.status = row.status || 'ready';
+        const dateLabel = row.date
+          ? formatDateForDisplay(row.date)
+          : row.rawDate
+          ? formatDateForDisplay(row.rawDate)
+          : '-';
+        const columns = [
+          row.orderCode || '-',
+          dateLabel || '-',
+          row.cupom || '-',
+          row.influencerName || '-',
+          row.grossValue != null ? formatCurrency(row.grossValue) : '-',
+          formatCurrency(row.discount || 0),
+          row.netValue != null ? formatCurrency(row.netValue) : '-',
+          row.statusMessage || '-'
+        ];
+        columns.forEach((value, columnIndex) => {
+          const td = document.createElement('td');
+          if (columnIndex === columns.length - 1) {
+            const badge = document.createElement('span');
+            badge.className = 'status-badge';
+            badge.dataset.status = row.status || 'ready';
+            badge.textContent = value;
+            td.appendChild(badge);
+          } else {
+            td.textContent = value;
+          }
+          tr.appendChild(td);
+        });
+        fragment.appendChild(tr);
+      });
+
+      importPreviewTableBody.appendChild(fragment);
+      showElement(importPreviewWrapper);
+      updateImportActionsState(rows);
+
+      if (importSummaryEl) {
+        const total = rows.length;
+        const successCount = rows.filter((row) => row.status === 'success').length;
+        const readyCount = rows.filter((row) => row.status === 'ready').length;
+        const warningCount = rows.filter((row) => row.status === 'warning' || row.status === 'skipped').length;
+        const errorCount = rows.filter((row) => row.status === 'error' || row.status === 'failed').length;
+
+        importSummaryEl.innerHTML = '';
+        const summaryItems = [
+          { count: total, label: 'itens processados', status: 'info' },
+          { count: successCount, label: 'importados', status: 'success' },
+          { count: readyCount, label: 'prontos para importar', status: 'ready' },
+          { count: warningCount, label: 'com alerta', status: 'warning' },
+          { count: errorCount, label: 'com erro', status: 'error' }
+        ].filter((item) => item.count > 0);
+
+        summaryItems.forEach((item) => {
+          const span = document.createElement('span');
+          span.dataset.status = item.status;
+          span.innerHTML = `<strong>${item.count}</strong> ${item.label}`;
+          importSummaryEl.appendChild(span);
+        });
+
+        if (summaryItems.length) {
+          showElement(importSummaryEl);
+        } else {
+          hideElement(importSummaryEl);
+        }
+      }
+    };
+
+    const applyRowError = (row, message) => {
+      if (!row) return;
+      row.canImport = false;
+      if (row.status !== 'success') {
+        row.status = 'error';
+        if (row.statusMessage && row.statusMessage.includes(message)) {
+          return;
+        }
+        if (row.statusMessage && row.statusMessage.trim() && row.statusMessage !== message) {
+          row.statusMessage = `${row.statusMessage} ${message}`.trim();
+        } else {
+          row.statusMessage = message;
+        }
+      }
+    };
+
+    const markFileDuplicates = (rows = []) => {
+      const seen = new Map();
+      rows.forEach((row) => {
+        if (!row?.orderCodeNormalized) return;
+        const key = row.orderCodeNormalized;
+        if (!seen.has(key)) {
+          seen.set(key, row);
+          return;
+        }
+        const message = 'Pedido duplicado no arquivo.';
+        applyRowError(row, message);
+        const first = seen.get(key);
+        if (first) {
+          applyRowError(first, message);
+        }
+      });
+    };
+
+    const fetchExistingOrders = async (orderCodes = []) => {
+      const unique = Array.from(new Set(orderCodes.filter(Boolean)));
+      if (!unique.length) return [];
+      try {
+        const response = await apiFetch('/sales/check-orders', { method: 'POST', body: { orders: unique } });
+        return Array.isArray(response) ? response : [];
+      } catch (error) {
+        if (error.status === 401) {
+          logout();
+          return [];
+        }
+        throw error;
+      }
+    };
+
+    const flagExistingOrders = (rows = [], existing = []) => {
+      if (!rows.length || !existing.length) return;
+      const map = new Map();
+      rows.forEach((row) => {
+        if (!row.orderCodeNormalized) return;
+        const key = row.orderCodeNormalized;
+        if (!map.has(key)) map.set(key, []);
+        map.get(key).push(row);
+      });
+
+      existing.forEach((item) => {
+        const key = normalizeOrderCode(item.order_code || item.orderCode);
+        if (!key || !map.has(key)) return;
+        const details = [];
+        if (item.cupom) details.push(`cupom ${item.cupom}`);
+        if (item.date) details.push(`em ${formatDateForDisplay(item.date)}`);
+        const suffix = details.length ? ` (${details.join(' - ')})` : '';
+        const message = `Pedido já importado anteriormente${suffix}.`;
+        map.get(key).forEach((row) => applyRowError(row, message));
+      });
+    };
+
+    const updateImportActionsState = (rows = []) => {
+      if (!importActionButtons) return;
+      if (!Array.isArray(rows) || rows.length === 0) {
+        hideElement(importActionButtons);
+        if (saveImportButton) saveImportButton.disabled = false;
+        if (cancelImportButton) cancelImportButton.disabled = false;
+        return;
+      }
+      showElement(importActionButtons);
+      const readyCount = rows.filter((row) => row.canImport).length;
+      if (saveImportButton) saveImportButton.disabled = readyCount === 0;
+      if (cancelImportButton) cancelImportButton.disabled = false;
+    };
+
+    const setImportActionsBusy = (busy) => {
+      const buttons = [saveImportButton, cancelImportButton, clearImportButton];
+      buttons.forEach((button) => {
+        if (!button) return;
+        if (busy) {
+          button.dataset.prevDisabled = button.disabled ? 'true' : 'false';
+          button.disabled = true;
+        } else {
+          if (button.dataset.prevDisabled !== 'true') {
+            button.disabled = false;
+          }
+          delete button.dataset.prevDisabled;
+        }
+      });
+      if (!busy) {
+        updateImportActionsState(pendingImportEntries);
+      }
+    };
+
+      const clearImportState = () => {
+        importSalesForm?.reset();
+        importSalesForm?.querySelectorAll('[aria-invalid="true"]').forEach((field) => field.removeAttribute('aria-invalid'));
+        setMessage(importMessageEl, '', '');
+        hideElement(importSummaryEl);
+        hideElement(importPreviewWrapper);
+        hideElement(importActionButtons);
+        pendingImportEntries = [];
+        if (importSalesFileInput) importSalesFileInput.value = '';
+        if (importSalesTextInput) importSalesTextInput.value = '';
+        if (importPreviewTableBody) importPreviewTableBody.innerHTML = '';
+        if (saveImportButton) saveImportButton.disabled = false;
+        if (cancelImportButton) cancelImportButton.disabled = false;
+      };
+
+    const setFormBusy = (formEl, busy) => {
+      if (!formEl) return;
+      const elements = Array.from(formEl.elements || []);
+      elements.forEach((element) => {
+        if (busy) {
+          element.dataset.prevDisabled = element.disabled ? 'true' : 'false';
+          element.disabled = true;
+        } else {
+          if (element.dataset.prevDisabled !== 'true') {
+            element.disabled = false;
+          }
+          delete element.dataset.prevDisabled;
+        }
+      });
+    };
+
+    clearImportButton?.addEventListener('click', (event) => {
+      event.preventDefault();
+      clearImportState();
+    });
+
+      importSalesForm?.addEventListener('submit', async (event) => {
+        event.preventDefault();
+
+        const file = importSalesFileInput?.files?.[0] || null;
+        const pastedText = importSalesTextInput?.value?.trim() || '';
+        const hasFile = Boolean(file);
+        const hasPastedText = Boolean(pastedText);
+
+        flagInvalidField(importSalesTextInput, hasPastedText || hasFile);
+        flagInvalidField(importSalesFileInput, hasFile || hasPastedText);
+
+        if (!hasFile && !hasPastedText) {
+          setMessage(importMessageEl, 'Cole as vendas ou selecione um arquivo JSON para importar.', 'error');
+          focusFirstInvalidField(importSalesForm);
+          return;
+        }
+
+        if (!influencers.length) {
+          setMessage(importMessageEl, 'Carregando influenciadoras cadastradas. Aguarde um instante e tente novamente.', 'info');
+          await loadInfluencersForSales();
+          if (!influencers.length) {
+            setMessage(importMessageEl, 'Cadastre influenciadoras com cupom antes de importar as vendas.', 'error');
+            return;
+          }
+        }
+
+        setFormBusy(importSalesForm, true);
+        const processingMessage = hasFile && hasPastedText
+          ? 'Processando dados colados e arquivo selecionado...'
+          : hasFile
+          ? 'Lendo arquivo e preparando as vendas...'
+          : 'Processando dados colados...';
+        setMessage(importMessageEl, processingMessage, 'info');
+
+        try {
+          let rawEntries = [];
+          if (hasPastedText) {
+            rawEntries = rawEntries.concat(parsePastedSalesText(pastedText));
+          }
+          if (hasFile) {
+            const fileContent = await readFileAsText(file);
+            let parsed;
+            try {
+              parsed = JSON.parse(fileContent);
+            } catch (parseError) {
+              throw new Error('O arquivo selecionado não contém um JSON válido.');
+            }
+            rawEntries = rawEntries.concat(extractArrayFromData(parsed));
+          }
+
+          if (!rawEntries.length) {
+            throw new Error('Nenhuma venda foi encontrada nos dados informados.');
+          }
+
+          const normalizedEntries = normalizeImportEntries(rawEntries);
+
+          normalizedEntries
+            .filter((item) => item.status === 'warning' && !item.canImport)
+            .forEach((item) => {
+              item.status = 'skipped';
+              item.statusMessage = 'Cupom não cadastrado. Cadastre-o e tente novamente.';
+            });
+
+          markFileDuplicates(normalizedEntries);
+
+          const existingOrders = await fetchExistingOrders(
+            normalizedEntries.map((item) => item.orderCodeNormalized)
+          );
+          flagExistingOrders(normalizedEntries, existingOrders);
+
+          pendingImportEntries = normalizedEntries;
+          renderImportPreview(pendingImportEntries);
+
+          if (!pendingImportEntries.length) {
+            setMessage(importMessageEl, 'Nenhuma venda válida foi identificada.', 'error');
+            return;
+          }
+
+          const readyCount = pendingImportEntries.filter((item) => item.canImport).length;
+          if (readyCount > 0) {
+            setMessage(
+              importMessageEl,
+              'Revise as vendas abaixo e clique em "Salvar importação" ou "Cancelar".',
+              'info'
+            );
+          } else {
+            setMessage(
+              importMessageEl,
+              'Nenhuma venda está pronta para importação. Revise os avisos destacados na tabela.',
+              'error'
+            );
+          }
+        } catch (error) {
+          setMessage(importMessageEl, error.message || 'Não foi possível processar os dados informados.', 'error');
+          hideElement(importSummaryEl);
+          hideElement(importPreviewWrapper);
+          hideElement(importActionButtons);
+          pendingImportEntries = [];
+          if (importPreviewTableBody) importPreviewTableBody.innerHTML = '';
+        } finally {
+          setFormBusy(importSalesForm, false);
+        }
+      });
+
+      saveImportButton?.addEventListener('click', async (event) => {
+        event.preventDefault();
+        if (!pendingImportEntries.length) {
+          setMessage(importMessageEl, 'Nenhuma venda pendente para salvar.', 'info');
+          return;
+        }
+
+        const importableEntries = pendingImportEntries.filter((item) => item.canImport);
+        if (!importableEntries.length) {
+          setMessage(
+            importMessageEl,
+            'Nenhuma venda está pronta para importação. Revise os avisos destacados na tabela.',
+            'error'
+          );
+          updateImportActionsState(pendingImportEntries);
+          return;
+        }
+
+        setImportActionsBusy(true);
+        setFormBusy(importSalesForm, true);
+        setMessage(importMessageEl, 'Enviando vendas para o sistema...', 'info');
+
+        let successCount = 0;
+        let failureCount = 0;
+
+        try {
+          for (const item of importableEntries) {
+            try {
+              await apiFetch('/sales', {
+                method: 'POST',
+                body: {
+                  cupom: item.cupom,
+                  date: item.date,
+                  grossValue: item.grossValue,
+                  discount: item.discount || 0,
+                  orderCode: item.orderCodeNormalized || item.orderCode
+                }
+              });
+              item.status = 'success';
+              item.statusMessage = 'Importada com sucesso.';
+              item.canImport = false;
+              successCount += 1;
+            } catch (error) {
+              if (error.status === 401) {
+                logout();
+                return;
+              }
+              item.status = 'failed';
+              item.statusMessage = error.message || 'Erro ao importar venda.';
+              item.canImport = false;
+              failureCount += 1;
+            }
+          }
+
+          renderImportPreview(pendingImportEntries);
+
+          if (importSalesFileInput) importSalesFileInput.value = '';
+          if (importSalesTextInput) importSalesTextInput.value = '';
+
+          if (successCount && !failureCount) {
+            setMessage(importMessageEl, `Importação concluída com ${successCount} vendas.`, 'success');
+          } else if (successCount && failureCount) {
+            setMessage(
+              importMessageEl,
+              `Importação finalizada com alertas: ${successCount} vendas criadas e ${failureCount} falharam.`,
+              'info'
+            );
+          } else {
+            setMessage(importMessageEl, 'Nenhuma venda foi importada. Verifique os dados e tente novamente.', 'error');
+          }
+
+          if (successCount && currentSalesInfluencerId) {
+            await loadSalesForInfluencer(currentSalesInfluencerId, { showStatus: false });
+            setMessage(messageEl, 'Vendas atualizadas após importação.', 'success');
+          }
+        } catch (error) {
+          setMessage(importMessageEl, error.message || 'Não foi possível importar as vendas.', 'error');
+        } finally {
+          setImportActionsBusy(false);
+          setFormBusy(importSalesForm, false);
+        }
+      });
+
+      cancelImportButton?.addEventListener('click', (event) => {
+        event.preventDefault();
+        clearImportState();
+        setMessage(importMessageEl, 'Importação cancelada.', 'info');
+      });
 
     const getInfluencerByCoupon = (coupon) => {
       if (!coupon) return undefined;
@@ -1028,26 +1903,27 @@
     const renderSalesTable = () => {
       if (!salesTableBody) return;
       salesTableBody.innerHTML = '';
-      if (!Array.isArray(sales) || sales.length === 0) {
-        const emptyRow = document.createElement('tr');
-        const emptyCell = document.createElement('td');
-        emptyCell.colSpan = 7;
-        emptyCell.className = 'empty';
-        emptyCell.textContent = 'Nenhuma venda cadastrada.';
-        emptyRow.appendChild(emptyCell);
-        salesTableBody.appendChild(emptyRow);
-        return;
-      }
-      const fragment = document.createDocumentFragment();
-      sales.forEach((sale) => {
-        const tr = document.createElement('tr');
-        tr.dataset.id = String(sale.id);
-        const cells = [
-          sale.date || '-',
-          sale.cupom || '-',
-          formatCurrency(sale.gross_value),
-          formatCurrency(sale.discount),
-          formatCurrency(sale.net_value),
+        if (!Array.isArray(sales) || sales.length === 0) {
+          const emptyRow = document.createElement('tr');
+          const emptyCell = document.createElement('td');
+          emptyCell.colSpan = 8;
+          emptyCell.className = 'empty';
+          emptyCell.textContent = 'Nenhuma venda cadastrada.';
+          emptyRow.appendChild(emptyCell);
+          salesTableBody.appendChild(emptyRow);
+          return;
+        }
+        const fragment = document.createDocumentFragment();
+        sales.forEach((sale) => {
+          const tr = document.createElement('tr');
+          tr.dataset.id = String(sale.id);
+          const cells = [
+            sale.order_code || '-',
+            sale.date || '-',
+            sale.cupom || '-',
+            formatCurrency(sale.gross_value),
+            formatCurrency(sale.discount),
+            formatCurrency(sale.net_value),
           formatCurrency(sale.commission)
         ];
         cells.forEach((value) => {
@@ -1075,9 +1951,9 @@
       }
       salesSummaryEl.innerHTML = '';
       const totalNet = document.createElement('span');
-      totalNet.textContent = `Total liquido: ${formatCurrency(summary.total_net)}`;
+      totalNet.textContent = `Total em vendas: ${formatCurrency(summary.total_net)}`;
       const totalCommission = document.createElement('span');
-      totalCommission.textContent = `Comissao total: ${formatCurrency(summary.total_commission)}`;
+      totalCommission.textContent = `Sua comissão: ${formatCurrency(summary.total_commission)}`;
       salesSummaryEl.append(totalNet, totalCommission);
     };
 
@@ -1087,6 +1963,7 @@
       const currentCoupon = saleCouponSelect?.value || '';
       form.reset();
       if (keepCoupon && saleCouponSelect) saleCouponSelect.value = currentCoupon;
+      if (saleOrderInput) saleOrderInput.value = '';
       form.dataset.mode = 'create';
       const submitBtn = form.querySelector('button[type="submit"]');
       if (submitBtn) submitBtn.textContent = 'Registrar venda';
@@ -1204,6 +2081,7 @@
       const date = saleDateInput?.value || '';
       const gross = Number(saleGrossInput?.value || 0);
       const discount = Number(saleDiscountInput?.value || 0);
+      const orderCode = saleOrderInput?.value?.trim() || '';
 
       flagInvalidField(saleCouponSelect, Boolean(coupon));
       flagInvalidField(saleDateInput, Boolean(date));
@@ -1216,7 +2094,7 @@
         return;
       }
 
-      const payload = { cupom: coupon, date, grossValue: gross, discount };
+      const payload = { cupom: coupon, date, grossValue: gross, discount, orderCode: orderCode || null };
       const endpoint = saleEditingId ? `/sales/${saleEditingId}` : '/sales';
       const method = saleEditingId ? 'PUT' : 'POST';
 
@@ -1249,6 +2127,7 @@
         const submitBtn = form.querySelector('button[type="submit"]');
         if (submitBtn) submitBtn.textContent = 'Salvar venda';
         if (saleCouponSelect) saleCouponSelect.value = sale.cupom || '';
+        if (saleOrderInput) saleOrderInput.value = sale.order_code || '';
         if (saleDateInput) saleDateInput.value = sale.date || '';
         if (saleGrossInput) saleGrossInput.value = sale.gross_value != null ? String(sale.gross_value) : '';
         if (saleDiscountInput) saleDiscountInput.value = sale.discount != null ? String(sale.discount) : '';
@@ -1295,8 +2174,8 @@
     }
 
     const createCopyLinkElement = (value) => {
-      const wrapper = document.createElement('span');
-      wrapper.className = 'detail-value detail-value-with-action';
+      const wrapper = document.createElement('div');
+      wrapper.className = 'info-value detail-actions';
       if (!value?.url) {
         wrapper.textContent = '-';
         return wrapper;
@@ -1344,81 +2223,47 @@
         return createCopyLinkElement(value);
       }
       const el = document.createElement('span');
-      el.className = 'detail-value';
+      el.className = 'info-value';
       el.textContent = value == null || value === '' ? '-' : String(value);
       return el;
     };
 
-    const groups = [
-      {
-        title: 'Identidade',
-        items: [
-          ['Nome', data.nome],
-          ['Instagram', data.instagram],
-          ['Email', data.email],
-          ['Contato', data.contato]
-        ]
-      },
-      {
-        title: 'Performance',
-        items: [
-          ['Cupom', data.cupom],
-          ['Comissao (%)', data.commissionPercent],
-          ['Link compartilhavel', data.discountLink ? { type: 'copy-link', url: data.discountLink, label: data.discountLink, copyLabel: 'Copiar link' } : '-']
-        ]
-      },
-      {
-        title: 'Endereco',
-        items: [
-          ['CEP', data.cep],
-          ['Logradouro', data.logradouro],
-          ['Numero', data.numero],
-          ['Complemento', data.complemento],
-          ['Bairro', data.bairro],
-          ['Cidade', data.cidade],
-          ['Estado', data.estado]
-        ]
-      },
-      {
-        title: 'Acesso',
-        items: [
-          ['Login', data.loginEmail]
-        ]
-      }
+    const items = [
+      ['Nome', data.nome],
+      ['Cupom', data.cupom],
+      [
+        'Link',
+        data.discountLink
+          ? {
+              type: 'copy-link',
+              url: data.discountLink,
+              label: data.discountLink,
+              copyLabel: 'Copiar link'
+            }
+          : '-'
+      ]
     ];
 
-    const grid = document.createElement('div');
-    grid.className = 'details-grid';
+    const fragment = document.createDocumentFragment();
 
-    groups.forEach((group) => {
-      const card = document.createElement('div');
-      card.className = 'detail-card';
+    items.forEach(([label, value]) => {
+      const item = document.createElement('div');
+      item.className = 'info-item';
 
-      if (group.title) {
-        const heading = document.createElement('p');
-        heading.className = 'detail-card-title';
-        heading.textContent = group.title;
-        card.appendChild(heading);
+      const labelEl = document.createElement('span');
+      labelEl.className = 'info-label';
+      labelEl.textContent = `${label}:`;
+      item.appendChild(labelEl);
+
+      const valueEl = createValueElement(value);
+      if (valueEl) {
+        item.appendChild(valueEl);
       }
 
-      group.items.forEach(([label, value]) => {
-        const row = document.createElement('p');
-        row.className = 'detail-row';
-        const labelEl = document.createElement('strong');
-        labelEl.className = 'detail-label';
-        labelEl.textContent = label;
-        row.appendChild(labelEl);
-
-        const valueEl = createValueElement(value);
-        row.appendChild(valueEl);
-
-        card.appendChild(row);
-      });
-
-      grid.appendChild(card);
+      fragment.appendChild(item);
     });
 
-    container.appendChild(grid);
+    container.appendChild(fragment);
   };
 
   const initInfluencerPage = () => {
@@ -1438,7 +2283,7 @@
       if (!Array.isArray(rows) || rows.length === 0) {
         const emptyRow = document.createElement('tr');
         const emptyCell = document.createElement('td');
-        emptyCell.colSpan = 5;
+        emptyCell.colSpan = 4;
         emptyCell.className = 'empty';
         emptyCell.textContent = 'Nenhuma venda registrada.';
         emptyRow.appendChild(emptyCell);
@@ -1448,13 +2293,14 @@
       const fragment = document.createDocumentFragment();
       rows.forEach((sale) => {
         const tr = document.createElement('tr');
-        const cells = [
-          sale.date || '-',
-          formatCurrency(sale.gross_value),
-          formatCurrency(sale.discount),
-          formatCurrency(sale.net_value),
-          formatCurrency(sale.commission)
-        ];
+        const customerName =
+          sale.customer_name || sale.cliente || sale.customer || sale.client_name || sale.client || '-';
+        const valueToDisplay =
+          sale.net_value != null && sale.net_value !== ''
+            ? formatCurrency(sale.net_value)
+            : formatCurrency(sale.gross_value);
+        const statusLabel = sale.status || sale.status_label || sale.statusLabel || 'Concluída';
+        const cells = [sale.date || '-', customerName, valueToDisplay, statusLabel];
         cells.forEach((value) => {
           const td = document.createElement('td');
           td.textContent = value;
@@ -1473,9 +2319,9 @@
       }
       salesSummaryEl.innerHTML = '';
       const totalNet = document.createElement('span');
-      totalNet.textContent = `Total liquido: ${formatCurrency(summary.total_net)}`;
+      totalNet.textContent = `Total em vendas: ${formatCurrency(summary.total_net)}`;
       const totalCommission = document.createElement('span');
-      totalCommission.textContent = `Comissao total: ${formatCurrency(summary.total_commission)}`;
+      totalCommission.textContent = `Sua comissão: ${formatCurrency(summary.total_commission)}`;
       salesSummaryEl.append(totalNet, totalCommission);
     };
 
@@ -1500,7 +2346,7 @@
           renderSalesSummary(null);
         }
         if (!salesData?.length) {
-          setMessage(salesMessageEl, 'Nenhuma venda registrada ate o momento.', 'info');
+          setMessage(salesMessageEl, '', '');
         } else {
           setMessage(salesMessageEl, 'Vendas atualizadas com sucesso.', 'success');
         }
@@ -1528,7 +2374,7 @@
           return;
         }
         renderInfluencerDetails(detailsEl, formatInfluencerDetails(influencer));
-        setMessage(messageEl, 'Dados atualizados com sucesso, Pinklover! ??', 'success');
+        setMessage(messageEl, 'Dados atualizados com sucesso, Pinklover! 💗', 'success');
         loadInfluencerSales(influencer.id);
       } catch (error) {
         if (error.status === 401) {

--- a/public/master-home.html
+++ b/public/master-home.html
@@ -4,8 +4,57 @@
     <meta charset="UTF-8" />
     <meta http-equiv="refresh" content="0;url=master.html" />
     <title>Redirecionando...</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --pink-strong: #e4447a;
+        --pink-medium: #f07999;
+        --pink-light: #fbd3db;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+        font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: #fff;
+        background-image: radial-gradient(circle at top right, rgba(228, 68, 122, 0.15), transparent 58%),
+          radial-gradient(circle at bottom left, rgba(240, 121, 153, 0.2), transparent 60%),
+          linear-gradient(180deg, rgba(251, 211, 219, 0.28), rgba(255, 255, 255, 0.45));
+        color: var(--pink-strong);
+      }
+
+      .redirect-card {
+        background: rgba(255, 255, 255, 0.92);
+        padding: 24px 32px;
+        border-radius: 24px;
+        text-align: center;
+        box-shadow: 0 18px 40px rgba(228, 68, 122, 0.18);
+        border: 1px solid rgba(228, 68, 122, 0.28);
+      }
+
+      .redirect-card a {
+        color: var(--pink-medium);
+        font-weight: 600;
+        text-decoration: none;
+      }
+    </style>
   </head>
   <body>
-    <p>Redirecionando para <a href="master.html">painel master</a>...</p>
+    <div class="redirect-card">
+      <p>Redirecionando para <a href="master.html">painel master</a>...</p>
+    </div>
   </body>
 </html>

--- a/public/master-sales.html
+++ b/public/master-sales.html
@@ -16,6 +16,62 @@
       </header>
 
       <section class="card">
+        <h2>Importar vendas por período</h2>
+        <p class="note">
+          Cole os dados exportados da plataforma (como a tabela de pedidos) ou, se preferir, faça o upload do arquivo JSON. Após
+          importar, você continua podendo editar cada registro individualmente.
+        </p>
+        <form id="importSalesForm">
+          <div class="form-grid compact">
+            <label class="full-width">
+              Cole as vendas aqui*
+              <textarea
+                id="importSalesText"
+                name="salesText"
+                rows="8"
+                placeholder="Ex.: Número do pedido, data do pagamento, valor, cupom"
+              ></textarea>
+            </label>
+            <label>
+              Arquivo JSON
+              <input id="importSalesFile" name="salesFile" type="file" accept="application/json" />
+            </label>
+          </div>
+          <p class="note">
+            Dica: copie a tabela com as colunas Pedido, Data (Paid at), Valor (Subtotal) e Cupom (Discount Code). Quando o cupom
+            não estiver cadastrado, a linha aparecerá com alerta.
+          </p>
+          <div class="button-row">
+            <button type="submit">Importar vendas</button>
+            <button type="button" class="secondary-button" id="clearImportButton">Limpar</button>
+          </div>
+        </form>
+        <div id="importSalesMessage" class="message" aria-live="polite"></div>
+        <div id="importSummary" class="summary hidden" aria-live="polite"></div>
+        <div id="importActionButtons" class="import-actions hidden">
+          <button type="button" id="saveImportButton">Salvar importação</button>
+          <button type="button" class="secondary-button" id="cancelImportButton">Cancelar</button>
+        </div>
+        <div id="importPreview" class="table-wrapper hidden" aria-live="polite">
+          <table id="importPreviewTable">
+            <thead>
+              <tr>
+                <th>Pedido</th>
+                <th>Data</th>
+                <th>Cupom</th>
+                <th>Influenciadora</th>
+                <th>Bruto</th>
+                <th>Desconto</th>
+                <th>Liquido</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="card">
         <div class="link-grid" style="margin-bottom:16px;">
           <a class="link-card" href="master-create.html">Cadastrar</a>
           <a class="link-card" href="master-consult.html">Consulta</a>
@@ -28,6 +84,10 @@
               <select name="saleCoupon" id="saleCouponSelect" required>
                 <option value="">Selecione um cupom</option>
               </select>
+            </label>
+            <label>
+              Pedido
+              <input name="orderCode" type="text" placeholder="Ex.: #1040" />
             </label>
             <label>Data*<input name="saleDate" type="date" required /></label>
             <label>Valor bruto*<input name="grossValue" type="number" min="0" step="0.01" required /></label>
@@ -52,6 +112,7 @@
           <table id="salesTable">
             <thead>
               <tr>
+                <th>Pedido</th>
                 <th>Data</th>
                 <th>Cupom</th>
                 <th>Bruto</th>

--- a/public/style.css
+++ b/public/style.css
@@ -1,30 +1,22 @@
-:root {
-  color-scheme: light dark;
-  --bg-gradient-start: #f5f7fb;
-  --bg-gradient-end: #e4ecff;
-  --surface: rgba(255, 255, 255, 0.92);
-  --surface-muted: rgba(249, 250, 255, 0.9);
-  --border: rgba(99, 102, 241, 0.15);
-  --shadow-soft: 0 24px 60px rgba(15, 23, 42, 0.12);
-  --primary: #2563eb;
-  --primary-hover: #1d4ed8;
-  --secondary: #6b7280;
-  --secondary-hover: #4b5563;
-  --text: #0f172a;
-  --text-muted: #475569;
-  --accent-pink: #ec4899;
-  --accent-pink-hover: #db2777;
-  --radius-lg: 22px;
-  --radius-md: 14px;
-  --radius-sm: 10px;
-  --transition: 180ms ease;
-}
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap');
 
-body[data-page="influencer"] {
-  --primary: var(--accent-pink);
-  --primary-hover: var(--accent-pink-hover);
-  --bg-gradient-start: #fdf2f8;
-  --bg-gradient-end: #f5d0fe;
+:root {
+  --pink-strong: #e4447a;
+  --pink-medium: #f07999;
+  --pink-light: #fbd3db;
+  --pink-soft: #ffe6ef;
+  --text-primary: #361725;
+  --text-secondary: #6c3f52;
+  --text-muted: #8d6274;
+  --surface: #ffffff;
+  --surface-soft: rgba(255, 255, 255, 0.85);
+  --border: rgba(228, 68, 122, 0.22);
+  --shadow-hero: 0 26px 60px rgba(228, 68, 122, 0.22);
+  --shadow-card: 0 20px 48px rgba(228, 68, 122, 0.16);
+  --radius-lg: 28px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --transition: 180ms ease;
 }
 
 * {
@@ -34,132 +26,187 @@ body[data-page="influencer"] {
 html,
 body {
   margin: 0;
-  min-height: 100vh;
+  min-height: 100%;
 }
 
 body {
-  font-family: "Inter", "Segoe UI", Roboto, sans-serif;
-  color: var(--text);
-  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.12), transparent 55%),
-    radial-gradient(circle at bottom, rgba(14, 116, 144, 0.08), transparent 45%),
-    linear-gradient(180deg, var(--bg-gradient-start) 0%, var(--bg-gradient-end) 100%);
-  padding: clamp(32px, 5vw, 64px) clamp(16px, 6vw, 48px);
-  transition: background 300ms ease;
+  font-family: 'Montserrat', 'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: var(--text-primary);
+  background: #fff;
+  background-image: radial-gradient(circle at top right, rgba(228, 68, 122, 0.16), transparent 58%),
+    radial-gradient(circle at bottom left, rgba(240, 121, 153, 0.16), transparent 60%),
+    linear-gradient(180deg, rgba(251, 211, 219, 0.32), rgba(255, 255, 255, 0.42));
+  padding: clamp(24px, 5vw, 64px) clamp(16px, 6vw, 48px);
+  line-height: 1.6;
 }
 
 .container {
-  max-width: 1040px;
+  width: min(100%, 960px);
   margin: 0 auto;
   display: grid;
-  gap: clamp(20px, 4vw, 32px);
+  gap: clamp(24px, 4vw, 32px);
 }
 
 header {
+  background: linear-gradient(135deg, var(--pink-strong), var(--pink-medium));
+  color: #fff;
+  border-radius: var(--radius-lg);
+  padding: clamp(24px, 5vw, 36px);
+  box-shadow: var(--shadow-hero);
   display: grid;
   gap: 12px;
   text-align: center;
 }
 
 header h1 {
-  font-size: clamp(2.1rem, 4vw, 2.8rem);
   margin: 0;
+  font-size: clamp(1.9rem, 5vw, 2.6rem);
   font-weight: 700;
   letter-spacing: -0.01em;
 }
 
 header p {
   margin: 0;
-  color: var(--text-muted);
-  font-size: clamp(0.95rem, 2.5vw, 1.05rem);
+  font-size: clamp(0.95rem, 2.8vw, 1.08rem);
+  color: rgba(255, 255, 255, 0.88);
 }
 
 header button {
-  justify-self: left;
+  justify-self: end;
+  background: #fff;
+  color: var(--pink-strong);
+  border: none;
+  border-radius: 999px;
+  padding: 12px 26px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 18px 40px rgba(255, 255, 255, 0.42);
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+header button:hover,
+header button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 46px rgba(255, 255, 255, 0.5);
+  outline: none;
 }
 
 .card {
   background: var(--surface);
   border-radius: var(--radius-lg);
-  padding: clamp(20px, 4vw, 32px);
+  padding: clamp(24px, 4vw, 36px);
   border: 1px solid var(--border);
-  box-shadow: var(--shadow-soft);
-  backdrop-filter: blur(16px);
+  box-shadow: var(--shadow-card);
   display: grid;
   gap: clamp(18px, 3vw, 24px);
-  transition: transform var(--transition), box-shadow var(--transition);
-}
-
-.card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 32px 70px rgba(15, 23, 42, 0.14);
 }
 
 .card h2 {
   margin: 0;
-  font-size: clamp(1.3rem, 3vw, 1.6rem);
+  font-size: clamp(1.32rem, 3vw, 1.7rem);
   font-weight: 600;
+  text-align: center;
+  color: var(--text-primary);
+}
+
+.section-title {
+  font-size: 0.92rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--pink-strong);
 }
 
 .note {
-  font-size: 0.9rem;
-  color: var(--text-muted);
   margin: 0;
-}
-
-.info-card {
-  display: grid;
-  gap: 14px;
-}
-
-.info-list {
-  margin: 0;
-  padding-left: 18px;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   font-size: 0.95rem;
 }
 
-.info-list li {
-  margin-bottom: 6px;
+.link-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.link-card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--text-primary);
+  padding: 16px 20px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, rgba(251, 211, 219, 0.85), rgba(255, 255, 255, 0.92));
+  border: 1px solid rgba(228, 68, 122, 0.25);
+  box-shadow: 0 16px 34px rgba(228, 68, 122, 0.14);
+  transition: transform var(--transition), box-shadow var(--transition), color var(--transition);
+}
+
+.link-card:hover,
+.link-card:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 44px rgba(228, 68, 122, 0.22);
+  color: var(--pink-strong);
+  outline: none;
 }
 
 form {
   display: grid;
-  gap: 18px;
+  gap: clamp(18px, 3vw, 24px);
 }
 
 label {
   display: grid;
   gap: 8px;
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: 0.96rem;
+  color: var(--text-primary);
+}
+
+.help-text {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  line-height: 1.4;
 }
 
 input,
 select,
 textarea {
-  appearance: none;
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(99, 102, 241, 0.2);
+  width: 100%;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(228, 68, 122, 0.28);
+  background: rgba(251, 211, 219, 0.35);
   padding: 12px 16px;
-  font-size: 0.98rem;
-  background: var(--surface-muted);
-  color: inherit;
-  transition: border-color var(--transition), box-shadow var(--transition), transform var(--transition);
+  font-size: 1rem;
+  color: var(--text-primary);
+  transition: border-color var(--transition), box-shadow var(--transition), background var(--transition);
 }
 
 input:focus,
 select:focus,
 textarea:focus {
   outline: none;
-  border-color: rgba(37, 99, 235, 0.55);
-  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.18);
-  transform: translateY(-1px);
+  border-color: var(--pink-strong);
+  box-shadow: 0 0 0 4px rgba(228, 68, 122, 0.24);
+  background: #fff;
 }
 
-input[aria-invalid="true"],
-textarea[aria-invalid="true"] {
-  border-color: rgba(220, 38, 38, 0.6);
-  box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.2);
+input[readonly],
+select[readonly],
+textarea[readonly] {
+  background: rgba(251, 211, 219, 0.25);
+  cursor: not-allowed;
+}
+
+input[aria-invalid='true'],
+select[aria-invalid='true'],
+textarea[aria-invalid='true'] {
+  border-color: rgba(228, 68, 122, 0.7);
+  box-shadow: 0 0 0 3px rgba(228, 68, 122, 0.25);
 }
 
 .button-row {
@@ -168,91 +215,316 @@ textarea[aria-invalid="true"] {
   gap: 14px;
 }
 
+.import-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 16px;
+}
+
 button {
   border: none;
   border-radius: var(--radius-md);
-  padding: 12px 22px;
+  padding: 12px 24px;
   font-weight: 600;
+  font-size: 1rem;
   letter-spacing: 0.01em;
   cursor: pointer;
-  background: var(--primary);
+  background: linear-gradient(135deg, var(--pink-strong), var(--pink-medium));
   color: #fff;
-  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
-  box-shadow: 0 18px 36px rgba(37, 99, 235, 0.23);
+  transition: transform var(--transition), box-shadow var(--transition), filter var(--transition);
+  box-shadow: 0 18px 40px rgba(228, 68, 122, 0.28);
 }
 
-button:hover {
-  background: var(--primary-hover);
+button:hover,
+button:focus {
   transform: translateY(-1px);
-  box-shadow: 0 22px 44px rgba(37, 99, 235, 0.26);
+  box-shadow: 0 22px 48px rgba(228, 68, 122, 0.32);
+  outline: none;
 }
 
 button.secondary-button {
-  background: var(--secondary);
-  box-shadow: 0 16px 32px rgba(107, 114, 128, 0.2);
+  background: #fff;
+  color: var(--pink-strong);
+  border: 1px solid rgba(228, 68, 122, 0.4);
+  box-shadow: 0 16px 36px rgba(228, 68, 122, 0.18);
 }
 
-button.secondary-button:hover {
-  background: var(--secondary-hover);
+button.secondary-button:hover,
+button.secondary-button:focus {
+  background: rgba(251, 211, 219, 0.55);
 }
 
-[data-action="logout"] {
-  background: transparent;
-  color: var(--primary);
-  border: 1px solid rgba(37, 99, 235, 0.4);
+button:disabled,
+button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
   box-shadow: none;
+  transform: none;
 }
 
-[data-action="logout"]:hover {
-  background: rgba(37, 99, 235, 0.08);
+[data-action='logout'] {
+  background: rgba(255, 255, 255, 0.88);
+  color: var(--pink-strong);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  box-shadow: 0 18px 36px rgba(255, 255, 255, 0.38);
+}
+
+[data-action='logout']:hover,
+[data-action='logout']:focus {
+  background: #fff;
 }
 
 .message {
   min-height: 52px;
   border-radius: var(--radius-md);
-  border: 1px solid rgba(99, 102, 241, 0.2);
-  background: rgba(37, 99, 235, 0.08);
-  padding: 14px 16px;
+  border: 1px solid rgba(228, 68, 122, 0.25);
+  background: rgba(251, 211, 219, 0.45);
+  padding: 16px 18px;
   font-size: 0.95rem;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   transition: background var(--transition), border var(--transition), color var(--transition);
 }
 
-.message[data-type="success"] {
-  background: rgba(16, 185, 129, 0.12);
+.message[data-type='success'] {
+  background: rgba(52, 211, 153, 0.15);
   border-color: rgba(16, 185, 129, 0.35);
-  color: #047857;
+  color: #0f5132;
 }
 
-.message[data-type="error"] {
-  background: rgba(239, 68, 68, 0.12);
-  border-color: rgba(239, 68, 68, 0.4);
-  color: #b91c1c;
+.message[data-type='error'] {
+  background: rgba(248, 113, 113, 0.18);
+  border-color: rgba(220, 38, 38, 0.4);
+  color: #7f1d1d;
 }
 
-.message[data-type="info"] {
+.message[data-type='info'] {
+  background: rgba(79, 195, 247, 0.15);
+  border-color: rgba(14, 165, 233, 0.4);
+  color: #0b5c7a;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(228, 68, 122, 0.18);
+  background: #fff;
+  box-shadow: inset 0 0 0 1px rgba(251, 211, 219, 0.4);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 560px;
+}
+
+table thead tr {
+  background: linear-gradient(135deg, rgba(228, 68, 122, 0.95), rgba(240, 121, 153, 0.9));
+  color: #fff;
+}
+
+table th,
+table td {
+  padding: 14px 16px;
+  text-align: left;
+  font-size: 0.95rem;
+}
+
+table tbody tr:nth-child(even) {
+  background: rgba(251, 211, 219, 0.55);
+}
+
+table tbody tr:nth-child(odd) {
+  background: rgba(255, 255, 255, 0.92);
+}
+
+table tbody tr:hover {
+  background: rgba(240, 121, 153, 0.18);
+}
+
+table tbody td:last-child {
+  white-space: nowrap;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.88rem;
+  font-weight: 600;
+  background: rgba(14, 165, 233, 0.16);
+  color: #0b5c7a;
+  text-transform: none;
+}
+
+.status-badge[data-status='ready'] {
+  background: rgba(14, 165, 233, 0.16);
+  color: #0b5c7a;
+}
+
+.status-badge[data-status='success'] {
+  background: rgba(52, 211, 153, 0.18);
+  color: #0f5132;
+}
+
+.status-badge[data-status='failed'],
+.status-badge[data-status='error'] {
+  background: rgba(248, 113, 113, 0.18);
+  color: #7f1d1d;
+}
+
+.status-badge[data-status='warning'] {
+  background: rgba(251, 191, 36, 0.22);
+  color: #7c2d12;
+}
+
+.status-badge[data-status='skipped'] {
+  background: rgba(251, 191, 36, 0.22);
+  color: #7c2d12;
+}
+
+.status-badge[data-status='pending'] {
+  background: rgba(228, 68, 122, 0.18);
+  color: var(--text-primary);
+}
+
+.summary.hidden {
+  display: none !important;
+}
+
+#importPreviewTable tbody tr[data-status='success'] {
+  background: rgba(52, 211, 153, 0.12);
+}
+
+#importPreviewTable tbody tr[data-status='failed'],
+#importPreviewTable tbody tr[data-status='error'] {
+  background: rgba(248, 113, 113, 0.12);
+}
+
+#importPreviewTable tbody tr[data-status='warning'],
+#importPreviewTable tbody tr[data-status='skipped'] {
+  background: rgba(251, 191, 36, 0.14);
+}
+
+#importPreviewTable tbody tr[data-status='ready'] {
   background: rgba(14, 165, 233, 0.12);
-  border-color: rgba(14, 165, 233, 0.35);
-  color: #0f172a;
+}
+
+#importPreviewTable tbody tr td {
+  vertical-align: middle;
+}
+
+#importSummary span[data-status='success'] {
+  color: #0f5132;
+}
+
+#importSummary span[data-status='ready'] {
+  color: #0b5c7a;
+}
+
+#importSummary span[data-status='warning'],
+#importSummary span[data-status='skipped'] {
+  color: #7c2d12;
+}
+
+#importSummary span[data-status='error'],
+#importSummary span[data-status='failed'] {
+  color: #7f1d1d;
+}
+
+.summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  background: rgba(251, 211, 219, 0.6);
+  border: 1px solid rgba(228, 68, 122, 0.22);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.summary span {
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .influencers-list {
   display: grid;
-  gap: 16px;
+  gap: 18px;
 }
 
 .influencer-card {
   border-radius: var(--radius-md);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  padding: 18px;
-  background: #f07999;
-  box-shadow: 0 12px 28px #fbd3db;
+  border: 1px solid rgba(228, 68, 122, 0.28);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(251, 211, 219, 0.88));
+  box-shadow: 0 18px 38px rgba(228, 68, 122, 0.18);
+  padding: 20px;
   display: grid;
-  gap: 10px;
+  gap: 12px;
+}
+
+input[type='file'] {
+  padding: 10px 14px;
+  background: rgba(251, 211, 219, 0.35);
+  border-radius: var(--radius-sm);
+}
+
+input[type='file']::-webkit-file-upload-button {
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(228, 68, 122, 0.3);
+  border-radius: 999px;
+  padding: 8px 18px;
+  margin-right: 14px;
+  font-weight: 600;
+  color: var(--pink-strong);
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition), border var(--transition);
+}
+
+input[type='file']::-webkit-file-upload-button:hover,
+input[type='file']::-webkit-file-upload-button:focus {
+  background: rgba(228, 68, 122, 0.12);
+  color: var(--text-primary);
+  border-color: rgba(228, 68, 122, 0.45);
+}
+
+input[type='file']::file-selector-button {
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(228, 68, 122, 0.3);
+  border-radius: 999px;
+  padding: 8px 18px;
+  margin-right: 14px;
+  font-weight: 600;
+  color: var(--pink-strong);
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition), border var(--transition);
+}
+
+input[type='file']::file-selector-button:hover,
+input[type='file']::file-selector-button:focus {
+  background: rgba(228, 68, 122, 0.12);
+  color: var(--text-primary);
+  border-color: rgba(228, 68, 122, 0.45);
 }
 
 .influencer-card strong {
-  font-size: 1.1rem;
+  font-size: 1.08rem;
+  color: var(--pink-strong);
+}
+
+.influencer-card p {
+  margin: 0;
+  color: var(--text-secondary);
 }
 
 .influencer-card .actions {
@@ -261,648 +533,140 @@ button.secondary-button:hover {
   gap: 12px;
 }
 
-.details p,
-.influencer-card p {
-  margin: 0;
-  color: var(--text-muted);
-}
-
-.details h2 {
-  margin: 0 0 8px;
-}
-
 .empty {
   color: var(--text-muted);
   font-style: italic;
   text-align: center;
-  padding: 16px 0;
+  padding: 18px 0;
+}
+
+.details {
+  display: grid;
+  gap: 12px;
+}
+
+.details h2 {
+  margin: 0;
+}
+
+.details p {
+  margin: 0;
+  color: var(--text-secondary);
 }
 
 @media (max-width: 900px) {
   body {
-    padding: clamp(24px, 5vw, 40px) clamp(14px, 6vw, 28px);
-  }
-
-  .card {
-    padding: clamp(18px, 5vw, 28px);
-  }
-
-  .form-grid.two-columns,
-  .form-grid.three-columns {
-    grid-template-columns: 1fr;
-  }
-
-  button {
-    width: 100%;
-    justify-content: center;
+    padding: clamp(20px, 6vw, 48px) clamp(12px, 6vw, 28px);
   }
 
   .button-row {
     flex-direction: column;
   }
+
+  button,
+  .button-row > * {
+    width: 100%;
+  }
+
+  table {
+    min-width: 520px;
+  }
 }
 
-@media (max-width: 520px) {
-  header h1 {
-    font-size: 1.8rem;
+@media (max-width: 540px) {
+  header {
+    text-align: left;
+    gap: 16px;
+  }
+
+  header button {
+    justify-self: stretch;
   }
 
   .card {
-    border-radius: 18px;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  body {
-    background: radial-gradient(circle at top, rgba(236, 72, 153, 0.1), transparent 55%),
-      radial-gradient(circle at bottom, rgba(37, 99, 235, 0.18), transparent 40%),
-      linear-gradient(180deg, rgba(15, 23, 42, 0.92) 0%, rgba(2, 6, 23, 0.98) 100%);
-    color: var(--text-dark);
+    padding: clamp(20px, 6vw, 28px);
   }
 
-  header p {
-    color: rgba(226, 232, 240, 0.72);
-  }
-
-  .card {
-    background: rgba(15, 23, 42, 0.9);
-    border-color: rgba(56, 189, 248, 0.1);
-    box-shadow: 0 28px 60px rgba(2, 6, 23, 0.55);
-  }
-
-  input,
-  select,
-  textarea {
-    background: #fbd3db;
-    border-color: rgba(99, 102, 241, 0.25);
-    color: var(--text-dark);
-  }
-
-  .message {
-    background: rgba(37, 99, 235, 0.18);
-    border-color: rgba(59, 130, 246, 0.3);
-    color: rgba(226, 232, 240, 0.86);
-  }
-
-  .influencer-card {
-    background: rgba(15, 23, 42, 0.88);
-  }
-:root {
-  --pink-dark: #e4447a;
-  --pink-medium: #f07999;
-  --pink-light: #fbd3db;
-}
-
-/* Centralização, fundo e cor base */
-body[data-page="login"] {
-  min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: radial-gradient(circle, var(--pink-light) 55%, var(--pink-medium) 130%);
-  background-attachment: fixed;
-  color: var(--pink-dark);
-  margin: 0;
-  padding: 0;
-}
-
-/* Tamanho do container */
-body[data-page="login"] .container {
-  width: 100%;
-  max-width: 490px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 28px;
-  text-align: center;
-  z-index: 1;
-}
-
-/* Cartão visual */
-body[data-page="login"] .card {
-  width: 100%;
-  border-radius: 38px;
-  padding: clamp(40px, 8vw, 60px);
-  background: #fff;
-  box-shadow: 0 0 80px var(--pink-light), 0 2px 12px 0 rgba(228,68,122,.08);
-  border: 3px solid var(--pink-medium);
-  z-index: 2;
-}
-
-/* Título */
-body[data-page="login"] h2 {
-  color: var(--pink-dark);
-  font-size: 2.3rem;
-  font-weight: 700;
-  margin-bottom: 18px;
-  letter-spacing: -0.02em;
-}
-
-/* Label destacado */
-body[data-page="login"] label {
-  text-align: left;
-  font-size: 1.1em;
-  color: var(--pink-dark);
-  font-weight: 600;
-  display: block;
-  margin-bottom: 8px;
-}
-
-/* Campos do formulário */
-body[data-page="login"] input {
-  width: 100%;
-  border-radius: 22px;
-  border: 2.5px solid var(--pink-medium);
-  background: var(--pink-light);
-  color: #2d2d2d;
-  padding: 16px 22px;
-  font-size: 1.15rem;
-  margin-bottom: 16px;
-  margin-top: 4px;
-  transition: border-color 180ms, box-shadow 180ms;
-  outline: none;
-  box-sizing: border-box;
-}
-
-body[data-page="login"] input:focus {
-  border-color: var(--pink-dark);
-  box-shadow: 0 0 0 4px var(--pink-medium);
-}
-
-/* Botão de ação */
-body[data-page="login"] button[type="submit"] {
-  background: linear-gradient(135deg, var(--pink-dark), var(--pink-medium));
-  box-shadow: 0 10px 34px var(--pink-light);
-  border-radius: 28px;
-  letter-spacing: 0.03em;
-  font-size: 1.15rem;
-  padding: 18px 0;
-  font-weight: 700;
-  width: 100%;
-  color: #fff;
-  border: none;
-  margin-top: 8px;
-  cursor: pointer;
-  transition: background 180ms, transform 180ms;
-}
-
-body[data-page="login"] button[type="submit"]:hover {
-  background: linear-gradient(135deg, var(--pink-medium), var(--pink-dark));
-  transform: translateY(-2px) scale(1.03);
-}
-
-/* Responsividade */
-@media (max-width: 650px) {
-  body[data-page="login"] .container {
-    max-width: 99vw;
-    gap: 18px;
-  }
-  body[data-page="login"] .card {
-    border-radius: 24px;
-    padding: clamp(16px, 8vw, 28px);
-  }
-  body[data-page="login"] h2 {
-    font-size: 1.4rem;
-  }
-  body[data-page="login"] input,
-  body[data-page="login"] button[type="submit"] {
-    font-size: 1rem;
-    padding: 13px 10px;
+  table {
+    min-width: 460px;
   }
 }
 
 .form-grid {
   display: grid;
-  gap: clamp(12px, 3vw, 16px);
+  gap: clamp(14px, 3vw, 18px);
 }
 
 .form-grid.compact {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: clamp(12px, 3vw, 18px);
 }
 
-.form-grid.compact label {
-  font-size: 0.9rem;
-}
-
-.form-grid.compact input,
-.form-grid.compact select,
-.form-grid.compact textarea {
-  border-radius: 14px;
-  padding: 10px 14px;
-}
-
-body[data-page="master"] #createInfluencerForm {
-  display: grid;
-  gap: clamp(16px, 3vw, 20px);
-}
-
-body[data-page="master"] #createInfluencerForm .section-title {
-  font-size: 0.85rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(15, 23, 42, 0.6);
-  margin: 4px 0;
-}
-
-body[data-page="master"] #createInfluencerForm[data-mode="edit"] .credentials-group {
-  display: none;
+.form-grid .full-width {
+  grid-column: 1 / -1;
 }
 
 .credentials-group {
   display: grid;
-  gap: 12px;
-  padding: 14px;
-  border-radius: 16px;
-  background: rgba(59, 130, 246, 0.08);
-  border: 1px solid rgba(37, 99, 235, 0.15);
+  gap: 14px;
+  padding: 18px;
+  border-radius: var(--radius-md);
+  background: rgba(251, 211, 219, 0.55);
+  border: 1px solid rgba(228, 68, 122, 0.28);
 }
 
-.credentials-group label {
+body[data-page='master-create'] #createInfluencerForm[data-mode='edit'] .credentials-group {
+  display: none;
+}
+
+.summary strong {
+  color: var(--pink-strong);
+}
+
+/* Login page adjustments */
+body[data-page='login'] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(40px, 8vw, 96px);
+}
+
+body[data-page='login'] .container {
+  width: min(100%, 460px);
+}
+
+body[data-page='login'] .card {
+  gap: 24px;
+  text-align: left;
+  border: 1px solid rgba(228, 68, 122, 0.35);
+}
+
+body[data-page='login'] h2 {
+  text-align: center;
+  font-size: clamp(1.8rem, 4vw, 2.2rem);
+  color: var(--pink-strong);
   margin: 0;
 }
 
-body[data-page="master"] .button-row {
-  justify-content: flex-start;
+body[data-page='login'] label {
+  font-size: 1rem;
 }
 
-@media (max-width: 720px) {
-  .form-grid.compact {
-    grid-template-columns: 1fr;
-  }
-
-  body[data-page="master"] .button-row {
-    flex-direction: column;
-  }
+body[data-page='login'] input {
+  border-radius: 22px;
 }
 
-
-.table-wrapper {
-  overflow-x: auto;
-  margin-top: 12px;
-}
-
-.table-wrapper table {
+body[data-page='login'] button[type='submit'] {
   width: 100%;
-  border-collapse: collapse;
+  border-radius: 26px;
+  font-size: 1.05rem;
+  padding-block: 16px;
 }
 
-.table-wrapper th,
-.table-wrapper td {
-  padding: 10px 12px;
-  text-align: left;
-  border-bottom: 1px solid #e0e0e0;
-  white-space: nowrap;
-}
-
-.table-wrapper tbody tr:hover {
-  background: #f5f5f5;
-}
-
-.summary {
-  margin-top: 12px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
-  font-weight: 600;
-}
-
-.summary span {
-  display: inline-block;
-}
-.table-wrapper tr[data-clickable] {
-  cursor: pointer;
-}
-
-.table-wrapper tr[data-clickable]:hover {
-  background: #e8f0fe;
-}
-.link-grid {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.link-card {
-  display: block;
-  padding: 18px 20px;
-  background: #f5f7fb;
-  border: 1px solid #d3d8e4;
-  border-radius: 8px;
-  font-weight: 600;
-  color: #1a2a4a;
-  text-decoration: none;
-  text-align: center;
-  transition: background 0.2s ease, border-color 0.2s ease;
-}
-
-.link-card:hover {
-  background: #e6ecfc;
-  border-color: #9aaee5;
-}
-.pinklover-body {
-  background: #fbd3db; /* Fundo bem claro da paleta HidraPink */
-  color: #222;         /* Texto preto para altíssimo contraste e legibilidade */
-  min-height: 100vh;
-}
-
-.pinklover-container {
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
-}
-
-.pinklover-hero {
-  position: relative;
-  padding: 80px 24px 120px;
-  text-align: center;
-  color: #fff;
-  overflow: hidden;
-}
-
-.pinklover-hero .hero-overlay {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, rgba(228, 68, 122, 0.85) 0%, rgba(240, 121, 153, 0.85) 45%, rgba(66, 27, 64, 0.9) 100%);
-  filter: drop-shadow(0 40px 70px rgba(228, 68, 122, 0.4));
-  z-index: 0;
-}
-
-.pinklover-hero .hero-content {
-  position: relative;
-  z-index: 1;
-  max-width: 640px;
-  margin: 0 auto;
-}
-
-.hero-eyebrow {
-  text-transform: uppercase;
-  letter-spacing: 4px;
-  font-size: 14px;
-  font-weight: 600;
-  margin-bottom: 16px;
-  color: #fbd3db;
-}
-
-.hero-title {
-  font-size: clamp(32px, 5vw, 48px);
-  margin: 0 0 12px;
-  font-weight: 700;
-}
-
-.hero-subtitle {
-  font-weight: 400;
-  font-size: 18px;
-  margin: 0 0 32px;
-  color: rgba(255, 255, 255, 0.85);
-}
-
-.hero-logout {
-  border: none;
-  background: #f07999;
-  color: #fff;
-  border-radius: 999px;
-  padding: 12px 32px;
-  font-weight: 600;
-  letter-spacing: 0.5px;
-  cursor: pointer;
-  box-shadow: 0 12px 30px rgba(228, 68, 122, 0.35);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.hero-logout:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 18px 36px rgba(228, 68, 122, 0.45);
-}
-
-.pinklover-main {
-  padding: 0 24px 60px;
-  margin-top: -80px;
-  display: grid;
-  gap: 32px;
-  max-width: 1100px;
-  width: 100%;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.pinklover-card {
-  background: rgba(15, 15, 40, 0.75);
-  border: 1px solid rgba(251, 211, 219, 0.15);
-  border-radius: 24px;
-  padding: 32px;
-  box-shadow: 0 35px 60px rgba(5, 5, 15, 0.45);
-  backdrop-filter: blur(12px);
-}
-
-.card-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 16px;
-  margin-bottom: 20px;
-}
-
-.card-header h2 {
-  margin: 0;
-  font-size: 24px;
-  font-weight: 600;
-  color: #e4447a;
-}
-
-.badge {
-  background: rgba(228, 68, 122, 0.18);
-  color: #fbd3db;
-  padding: 6px 16px;
-  border-radius: 999px;
-  font-size: 13px;
-  font-weight: 500;
-  letter-spacing: 0.4px;
-}
-
-.badge-soft {
-  background: rgba(240, 121, 153, 0.18);
-  color: #f07999;
-}
-
-.details p {
-  margin: 6px 0;
-  color: rgba(248, 236, 240, 0.9);
-  font-weight: 500;
-}
-
-.details-grid {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.detail-card {
-  background: rgba(251, 211, 219, 0.08);
-  border: 1px solid rgba(251, 211, 219, 0.18);
-  border-radius: 18px;
-  padding: 18px 20px;
-  color: rgba(248, 236, 240, 0.92);
-  box-shadow: inset 0 0 0 1px rgba(228, 68, 122, 0.05);
-}
-
-.detail-card-title {
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(251, 211, 219, 0.8);
-  margin-bottom: 10px;
-}
-
-.detail-card strong {
-  font-size: 13px;
-  letter-spacing: 0.4px;
-  text-transform: uppercase;
-  color: rgba(251, 211, 219, 0.9);
-  display: block;
-  margin-bottom: 4px;
-}
-
-.detail-row {
-  margin: 0 0 16px;
-}
-
-.detail-row:last-child {
-  margin-bottom: 0;
-}
-
-.detail-value {
-  display: block;
-  font-size: 16px;
-  font-weight: 600;
-  color: #fceff5;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-}
-
-.detail-value-with-action {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.detail-link {
-  color: #fbd3db;
-  text-decoration: underline;
-  text-decoration-color: rgba(228, 68, 122, 0.45);
-  overflow-wrap: anywhere;
-  word-break: break-word;
-}
-
-.detail-link:hover {
-  color: #ffffff;
-}
-
-.copy-button {
-  border: 1px solid rgba(240, 121, 153, 0.4);
-  background: rgba(240, 121, 153, 0.2);
-  color: #fceff5;
-  border-radius: 999px;
-  padding: 6px 14px;
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.4px;
-  cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
-}
-
-.copy-button:hover {
-  background: rgba(240, 121, 153, 0.35);
-  border-color: rgba(240, 121, 153, 0.6);
-}
-
-.copy-button.copied {
-  background: rgba(157, 207, 148, 0.35);
-  border-color: rgba(157, 207, 148, 0.55);
-  color: #dbf5df;
-}
-
-.copy-button.error {
-  background: rgba(228, 68, 122, 0.3);
-  border-color: rgba(228, 68, 122, 0.6);
-}
-
-.details strong {
-  color: #fceff5;
-  font-weight: 600;
-}
-
-.pinklover-table {
-  width: 100%;
-  border-collapse: collapse;
-  color: rgba(248, 236, 240, 0.94);
-}
-
-.pinklover-table thead {
-  background: rgba(228, 68, 122, 0.18);
-  color: #fceff5;
-}
-
-.pinklover-table th,
-.pinklover-table td {
-  padding: 14px 18px;
-  text-align: left;
-  border-bottom: 1px solid rgba(251, 211, 219, 0.12);
-}
-
-.pinklover-table tbody tr:hover {
-  background: rgba(240, 121, 153, 0.08);
-}
-
-.summary {
-  margin-top: 18px;
-  display: flex;
-  gap: 18px;
-  flex-wrap: wrap;
-  font-weight: 600;
-  color: #fceff5;
-}
-
-.summary-highlight {
-  background: rgba(240, 121, 153, 0.15);
-  padding: 16px 20px;
-  border-radius: 16px;
-  border: 1px solid rgba(240, 121, 153, 0.25);
-}
-
-.message {
-  margin-top: 18px;
-  padding: 14px 18px;
-  border-radius: 12px;
-  border: 1px solid transparent;
-  font-weight: 500;
-}
-
-.message[data-type="success"] {
-  background: rgba(157, 207, 148, 0.12);
-  border-color: rgba(157, 207, 148, 0.35);
-  color: #bfe6c3;
-}
-
-.message[data-type="error"] {
-  background: rgba(228, 68, 122, 0.12);
-  border-color: rgba(228, 68, 122, 0.35);
-  color: #fab1c7;
-}
-
-.message[data-type="info"] {
-  background: rgba(251, 211, 219, 0.1);
-  border-color: rgba(251, 211, 219, 0.2);
-  color: #fceff5;
-}
-
-@media (max-width: 768px) {
-  .pinklover-main {
-    grid-template-columns: 1fr;
-    margin-top: -60px;
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.001ms !important;
+    animation-duration: 0.001ms !important;
   }
 }


### PR DESCRIPTION
## Summary
- add a confirmation step to the master sales importer with duplicate detection, preview summaries, and save/cancel controls before writing new sales
- expose an order code column in the master sales dashboard form/table and style the new importer actions to match the HidraPink layout
- persist order codes on the backend with uniqueness enforcement and an API to detect previously imported orders during bulk uploads

## Testing
- npm test *(fails: better-sqlite3 binary unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e59ccbbf0c8323b05625e6ae8046e8