### PR TITLE
Add order number to sales management

### DIFF
--- a/public/master-sales.html
+++ b/public/master-sales.html
@@ -23,6 +23,7 @@
         </div>
         <form id="createSaleForm">
           <div class="form-grid compact">
+            <label>Pedido*<input name="orderNumber" type="text" required /></label>
             <label>
               Cupom*
               <select name="saleCoupon" id="saleCouponSelect" required>
@@ -52,12 +53,13 @@
           <table id="salesTable">
             <thead>
               <tr>
-                <th>Data</th>
+                <th>Pedido</th>
                 <th>Cupom</th>
-                <th>Bruto</th>
+                <th>Data</th>
+                <th>Valor bruto</th>
                 <th>Desconto</th>
-                <th>Liquido</th>
-                <th>Comissao</th>
+                <th>Valor liquido</th>
+                <th>Comissão</th>
                 <th>Acoes</th>
               </tr>
             </thead>

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -142,9 +142,16 @@ test('gestao de vendas vinculada a influenciadora', async () => {
   const saleResponse = await request(app)
     .post('/sales')
     .set('Authorization', `Bearer ${masterToken}`)
-    .send({ cupom: influencerPayload.cupom, date: '2025-10-01', grossValue: 1000, discount: 100 });
+    .send({
+      orderNumber: 'PED-001',
+      cupom: influencerPayload.cupom,
+      date: '2025-10-01',
+      grossValue: 1000,
+      discount: 100
+    });
 
   assert.strictEqual(saleResponse.status, 201);
+  assert.strictEqual(saleResponse.body.order_number, 'PED-001');
   assert.strictEqual(Number(saleResponse.body.net_value), 900);
   assert.strictEqual(Number(saleResponse.body.commission), 112.5);
   const saleId = saleResponse.body.id;
@@ -174,8 +181,15 @@ test('gestao de vendas vinculada a influenciadora', async () => {
   const updateSale = await request(app)
     .put(`/sales/${saleId}`)
     .set('Authorization', `Bearer ${masterToken}`)
-    .send({ cupom: influencerPayload.cupom, date: '2025-10-02', grossValue: 1000, discount: 50 });
+    .send({
+      orderNumber: 'PED-001-ALT',
+      cupom: influencerPayload.cupom,
+      date: '2025-10-02',
+      grossValue: 1000,
+      discount: 50
+    });
   assert.strictEqual(updateSale.status, 200);
+  assert.strictEqual(updateSale.body.order_number, 'PED-001-ALT');
   assert.strictEqual(Number(updateSale.body.net_value), 950);
   assert.strictEqual(Number(updateSale.body.commission), 118.75);
 


### PR DESCRIPTION
## Summary
- add mandatory order number field to the master sales form and display it in the listing
- persist the order identifier in sales APIs and schema for both SQLite and MySQL deployments
- update automated tests to exercise the new sales payload requirements

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e63212dfd483239ce7284e4ef25511