### PR TITLE
Prevent duplicate sale order numbers

### DIFF
--- a/public/master-sales.html
+++ b/public/master-sales.html
@@ -23,6 +23,7 @@
         </div>
         <form id="createSaleForm">
           <div class="form-grid compact">
+            <label>Pedido*<input name="orderNumber" type="text" required /></label>
             <label>
               Cupom*
               <select name="saleCoupon" id="saleCouponSelect" required>
@@ -52,12 +53,13 @@
           <table id="salesTable">
             <thead>
               <tr>
-                <th>Data</th>
+                <th>Pedido</th>
                 <th>Cupom</th>
-                <th>Bruto</th>
+                <th>Data</th>
+                <th>Valor bruto</th>
                 <th>Desconto</th>
-                <th>Liquido</th>
-                <th>Comissao</th>
+                <th>Valor liquido</th>
+                <th>Comissão</th>
                 <th>Acoes</th>
               </tr>
             </thead>

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -15,6 +15,8 @@ process.env.JWT_SECRET = 'test-secret';
 const app = require('../src/server');
 const db = require('../src/database');
 
+const selectSaleOrderNumberStmt = db.prepare('SELECT order_number FROM sales WHERE id = ?');
+
 const MASTER_EMAIL = process.env.MASTER_EMAIL || 'master@example.com';
 const MASTER_PASSWORD = process.env.MASTER_PASSWORD || 'master123';
 
@@ -142,12 +144,23 @@ test('gestao de vendas vinculada a influenciadora', async () => {
   const saleResponse = await request(app)
     .post('/sales')
     .set('Authorization', `Bearer ${masterToken}`)
-    .send({ cupom: influencerPayload.cupom, date: '2025-10-01', grossValue: 1000, discount: 100 });
+    .send({
+      orderNumber: 'PED-001',
+      cupom: influencerPayload.cupom,
+      date: '2025-10-01',
+      grossValue: 1000,
+      discount: 100
+    });
 
   assert.strictEqual(saleResponse.status, 201);
+  assert.strictEqual(saleResponse.body.order_number, 'PED-001');
   assert.strictEqual(Number(saleResponse.body.net_value), 900);
   assert.strictEqual(Number(saleResponse.body.commission), 112.5);
   const saleId = saleResponse.body.id;
+
+  const createdSaleRecord = selectSaleOrderNumberStmt.get(saleId);
+  assert.ok(createdSaleRecord, 'Venda deve ser persistida no banco de dados.');
+  assert.strictEqual(createdSaleRecord.order_number, 'PED-001');
 
   const listSales = await request(app)
     .get(`/sales/${influencerId}`)
@@ -171,13 +184,66 @@ test('gestao de vendas vinculada a influenciadora', async () => {
   assert.strictEqual(Number(consultRow.vendas_count), 1);
   assert.strictEqual(Number(consultRow.vendas_total), 900);
 
+  const duplicateSale = await request(app)
+    .post('/sales')
+    .set('Authorization', `Bearer ${masterToken}`)
+    .send({
+      orderNumber: 'PED-001',
+      cupom: influencerPayload.cupom,
+      date: '2025-10-04',
+      grossValue: 800,
+      discount: 0
+    });
+  assert.strictEqual(duplicateSale.status, 409);
+  assert.match(duplicateSale.body.error, /numero de pedido/i);
+
+  const secondSaleResponse = await request(app)
+    .post('/sales')
+    .set('Authorization', `Bearer ${masterToken}`)
+    .send({
+      orderNumber: 'PED-002',
+      cupom: influencerPayload.cupom,
+      date: '2025-10-05',
+      grossValue: 500,
+      discount: 0
+    });
+  assert.strictEqual(secondSaleResponse.status, 201);
+  const secondSaleId = secondSaleResponse.body.id;
+  const secondSaleRecord = selectSaleOrderNumberStmt.get(secondSaleId);
+  assert.ok(secondSaleRecord, 'Segunda venda deve ser persistida.');
+  assert.strictEqual(secondSaleRecord.order_number, 'PED-002');
+
+  const conflictingUpdate = await request(app)
+    .put(`/sales/${saleId}`)
+    .set('Authorization', `Bearer ${masterToken}`)
+    .send({
+      orderNumber: 'PED-002',
+      cupom: influencerPayload.cupom,
+      date: '2025-10-06',
+      grossValue: 1000,
+      discount: 50
+    });
+  assert.strictEqual(conflictingUpdate.status, 409);
+  assert.match(conflictingUpdate.body.error, /numero de pedido/i);
+
   const updateSale = await request(app)
     .put(`/sales/${saleId}`)
     .set('Authorization', `Bearer ${masterToken}`)
-    .send({ cupom: influencerPayload.cupom, date: '2025-10-02', grossValue: 1000, discount: 50 });
+    .send({
+      orderNumber: 'PED-001-ALT',
+      cupom: influencerPayload.cupom,
+      date: '2025-10-02',
+      grossValue: 1000,
+      discount: 50
+    });
   assert.strictEqual(updateSale.status, 200);
+  assert.strictEqual(updateSale.body.order_number, 'PED-001-ALT');
   assert.strictEqual(Number(updateSale.body.net_value), 950);
   assert.strictEqual(Number(updateSale.body.commission), 118.75);
+
+  const updatedSaleRecord = selectSaleOrderNumberStmt.get(saleId);
+  assert.ok(updatedSaleRecord, 'Venda atualizada deve existir no banco de dados.');
+  assert.strictEqual(updatedSaleRecord.order_number, 'PED-001-ALT');
 
   const consultAfterUpdate = await request(app)
     .get('/influenciadoras/consulta')
@@ -185,8 +251,8 @@ test('gestao de vendas vinculada a influenciadora', async () => {
   assert.strictEqual(consultAfterUpdate.status, 200);
   const consultRowUpdated = consultAfterUpdate.body.find((row) => row.id === influencerId);
   assert.ok(consultRowUpdated);
-  assert.strictEqual(Number(consultRowUpdated.vendas_count), 1);
-  assert.strictEqual(Number(consultRowUpdated.vendas_total), 950);
+  assert.strictEqual(Number(consultRowUpdated.vendas_count), 2);
+  assert.strictEqual(Number(consultRowUpdated.vendas_total), 1450);
 
   const influencerLogin = await login('vendas.influencer@example.com', 'SenhaInfluencer123');
   assert.strictEqual(influencerLogin.status, 200);
@@ -207,14 +273,14 @@ test('gestao de vendas vinculada a influenciadora', async () => {
     .get(`/sales/${influencerId}`)
     .set('Authorization', `Bearer ${influencerToken}`);
   assert.strictEqual(influencerSalesView.status, 200);
-  assert.strictEqual(influencerSalesView.body.length, 1);
+  assert.strictEqual(influencerSalesView.body.length, 2);
 
   const summaryAfterUpdate = await request(app)
     .get(`/sales/summary/${influencerId}`)
     .set('Authorization', `Bearer ${influencerToken}`);
   assert.strictEqual(summaryAfterUpdate.status, 200);
-  assert.strictEqual(Number(summaryAfterUpdate.body.total_net), 950);
-  assert.strictEqual(Number(summaryAfterUpdate.body.total_commission), 118.75);
+  assert.strictEqual(Number(summaryAfterUpdate.body.total_net), 1450);
+  assert.strictEqual(Number(summaryAfterUpdate.body.total_commission), 181.25);
 
   const deleteSale = await request(app)
     .delete(`/sales/${saleId}`)
@@ -225,8 +291,8 @@ test('gestao de vendas vinculada a influenciadora', async () => {
     .get(`/sales/summary/${influencerId}`)
     .set('Authorization', `Bearer ${masterToken}`);
   assert.strictEqual(summaryAfterDelete.status, 200);
-  assert.strictEqual(Number(summaryAfterDelete.body.total_net), 0);
-  assert.strictEqual(Number(summaryAfterDelete.body.total_commission), 0);
+  assert.strictEqual(Number(summaryAfterDelete.body.total_net), 500);
+  assert.strictEqual(Number(summaryAfterDelete.body.total_commission), 62.5);
 
   const consultAfterDelete = await request(app)
     .get('/influenciadoras/consulta')
@@ -234,8 +300,8 @@ test('gestao de vendas vinculada a influenciadora', async () => {
   assert.strictEqual(consultAfterDelete.status, 200);
   const consultRowAfterDelete = consultAfterDelete.body.find((row) => row.id === influencerId);
   assert.ok(consultRowAfterDelete);
-  assert.strictEqual(Number(consultRowAfterDelete.vendas_count), 0);
-  assert.strictEqual(Number(consultRowAfterDelete.vendas_total), 0);
+  assert.strictEqual(Number(consultRowAfterDelete.vendas_count), 1);
+  assert.strictEqual(Number(consultRowAfterDelete.vendas_total), 500);
 });
 
 after(() => {


### PR DESCRIPTION
## Summary
- add a unique index for `sales.order_number` in both MySQL and SQLite schema paths
- validate sale creation and update requests to reject duplicated order numbers with a 409 response
- extend the sales integration flow tests to cover duplicate handling scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e63212dfd483239ce7284e4ef25511