### PR TITLE
Atualiza painel da influenciadora com métricas ilustradas

### DIFF
--- a/public/influencer.html
+++ b/public/influencer.html
@@ -4,344 +4,36 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Painel Influenciadora | HidraPink</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
+    <link rel="stylesheet" href="style.css" />
     <script defer src="main.js"></script>
-    <style>
-      :root {
-        --pink-strong: #e4447a;
-        --pink-medium: #f07999;
-        --pink-light: #fbd3db;
-        --text-color: #361725;
-        --shadow: 0 26px 60px rgba(228, 68, 122, 0.22);
-      }
-
-      * {
-        box-sizing: border-box;
-      }
-
-      body {
-        margin: 0;
-        min-height: 100vh;
-        font-family: 'Montserrat', sans-serif;
-        background: #fff;
-        background-image: radial-gradient(circle at top right, rgba(228, 68, 122, 0.14), transparent 60%),
-          radial-gradient(circle at bottom left, rgba(240, 121, 153, 0.18), transparent 58%),
-          linear-gradient(180deg, rgba(251, 211, 219, 0.28), rgba(255, 255, 255, 0.4));
-        color: var(--text-color);
-        display: flex;
-        justify-content: center;
-        align-items: flex-start;
-        padding: 48px 16px 56px;
-      }
-
-      .pinklover-container {
-        width: 100%;
-        max-width: 600px;
-        display: flex;
-        flex-direction: column;
-        gap: 36px;
-      }
-
-      .pinklover-content {
-        display: flex;
-        flex-direction: column;
-        gap: 32px;
-      }
-
-      .pinklover-banner {
-        background: linear-gradient(115deg, var(--pink-strong), var(--pink-medium));
-        color: #ffffff;
-        text-align: center;
-        font-weight: 700;
-        font-size: 1.5rem;
-        padding: 18px 24px;
-        border-radius: 22px;
-        box-shadow: var(--shadow);
-        margin: 0;
-        letter-spacing: 0.02em;
-      }
-
-      .card {
-        background: linear-gradient(135deg, var(--pink-strong), var(--pink-medium));
-        border-radius: 26px;
-        padding: 28px 28px 32px;
-        box-shadow: var(--shadow);
-        color: var(--text-color);
-        position: relative;
-        overflow: hidden;
-        z-index: 0;
-      }
-
-      .card::before {
-        content: '';
-        position: absolute;
-        inset: 1px;
-        border-radius: 24px;
-        border: 1px solid rgba(255, 255, 255, 0.32);
-        pointer-events: none;
-        z-index: 0;
-      }
-
-      .card > * {
-        position: relative;
-        z-index: 1;
-      }
-
-      .card h2 {
-        margin: 0 0 18px;
-        font-size: 1.25rem;
-        font-weight: 700;
-        text-align: center;
-      }
-
-      .logout-wrapper {
-        display: flex;
-        justify-content: flex-end;
-        margin-top: 8px;
-      }
-
-      .logout-button {
-        margin: 0;
-        background: #ffffff;
-        color: var(--pink-strong);
-        border: none;
-        border-radius: 999px;
-        padding: 12px 28px;
-        font-weight: 700;
-        font-size: 0.95rem;
-        cursor: pointer;
-        transition: transform 0.2s ease, box-shadow 0.2s ease;
-        box-shadow: 0 12px 24px rgba(255, 255, 255, 0.25);
-      }
-
-      .logout-button:hover,
-      .logout-button:focus {
-        transform: translateY(-1px);
-        box-shadow: 0 16px 30px rgba(255, 255, 255, 0.35);
-        outline: none;
-      }
-
-      .influencer-info {
-        display: flex;
-        flex-direction: column;
-        gap: 16px;
-      }
-
-      .info-item {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 6px;
-      }
-
-      .info-label {
-        font-weight: 700;
-        font-size: 0.95rem;
-      }
-
-      .info-value {
-        font-weight: 500;
-        font-size: 1rem;
-        word-break: break-word;
-      }
-
-      .detail-actions {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 8px;
-      }
-
-      .copy-button {
-        background: rgba(255, 255, 255, 0.28);
-        color: var(--text-color);
-        border: none;
-        border-radius: 999px;
-        padding: 8px 16px;
-        font-weight: 600;
-        font-size: 0.85rem;
-        cursor: pointer;
-        transition: transform 0.2s ease, box-shadow 0.2s ease;
-      }
-
-      .copy-button:hover,
-      .copy-button:focus {
-        transform: translateY(-1px);
-        box-shadow: 0 6px 18px rgba(45, 13, 27, 0.15);
-        outline: none;
-      }
-
-      .copy-button.copied {
-        background: rgba(255, 255, 255, 0.48);
-      }
-
-      .copy-button.error {
-        background: rgba(255, 255, 255, 0.22);
-      }
-
-      .influencer-message {
-        margin-top: 16px;
-        font-size: 0.95rem;
-        text-align: center;
-      }
-
-      .sales-header {
-        display: flex;
-        flex-direction: column;
-        gap: 8px;
-        margin-bottom: 18px;
-      }
-
-      .table-wrapper {
-        overflow-x: auto;
-        background: rgba(255, 255, 255, 0.38);
-        border-radius: 20px;
-      }
-
-      table {
-        width: 100%;
-        border-collapse: collapse;
-        font-size: 0.95rem;
-        min-width: 460px;
-      }
-
-      th,
-      td {
-        padding: 14px 16px;
-        text-align: left;
-      }
-
-      th {
-        font-weight: 700;
-        text-transform: uppercase;
-        font-size: 0.8rem;
-        letter-spacing: 0.05em;
-        color: var(--text-color);
-        background: rgba(255, 255, 255, 0.7);
-      }
-
-      tbody tr:nth-child(odd) {
-        background: rgba(251, 211, 219, 0.45);
-      }
-
-      tbody tr:nth-child(even) {
-        background: rgba(255, 255, 255, 0.9);
-      }
-
-      tbody tr:hover {
-        background: rgba(240, 121, 153, 0.2);
-      }
-
-      td {
-        font-weight: 500;
-      }
-
-      td.empty {
-        text-align: center;
-        font-weight: 600;
-        padding: 24px 16px;
-      }
-
-      .sales-message,
-      .influencer-message {
-        margin: 16px 0 0;
-        text-align: center;
-        font-weight: 500;
-      }
-
-      .sales-message:empty,
-      .influencer-message:empty {
-        display: none;
-        margin: 0;
-      }
-
-      .influencer-message[data-type='success'],
-      .sales-message[data-type='success'] {
-        color: #0f5132;
-      }
-
-      .influencer-message[data-type='error'],
-      .sales-message[data-type='error'] {
-        color: #7a1634;
-      }
-
-      .influencer-message[data-type='info'],
-      .sales-message[data-type='info'] {
-        color: var(--text-color);
-        opacity: 0.85;
-      }
-
-      .summary {
-        margin-top: 20px;
-        display: flex;
-        flex-direction: column;
-        gap: 6px;
-        text-align: center;
-        font-weight: 600;
-      }
-
-      .summary span {
-        display: block;
-        padding: 10px 18px;
-        border-radius: 999px;
-        background: rgba(251, 211, 219, 0.55);
-      }
-
-      a.detail-link {
-        color: inherit;
-        font-weight: 600;
-        text-decoration: underline;
-      }
-
-      @media (max-width: 768px) {
-        body {
-          padding: 40px 16px 48px;
-        }
-
-        .pinklover-container {
-          gap: 30px;
-        }
-      }
-
-      @media (max-width: 480px) {
-        body {
-          padding: 32px 12px 40px;
-        }
-
-        .pinklover-content {
-          gap: 26px;
-        }
-
-        .card {
-          padding: 22px 20px 26px;
-        }
-
-        table {
-          min-width: 320px;
-        }
-      }
-    </style>
   </head>
   <body data-page="influencer">
-    <div class="pinklover-container" id="influencerPage">
-      <header class="pinklover-banner">Bem vinda, Pinklover.</header>
+    <div class="container" id="influencerPage">
+      <header>
+        <h1>Bem-vinda, Pinklover!</h1>
+        <p>Acompanhe seus dados e desempenho em um painel inspirado no master.</p>
+        <button type="button" data-action="logout">Sair</button>
+      </header>
 
-      <main class="pinklover-content">
+      <main class="dashboard-grid">
         <section class="card" aria-labelledby="influencer-info-title">
-          <h2 id="influencer-info-title">Suas informações</h2>
-          <div id="influencerDetails" class="influencer-info"></div>
-          <div id="influencerMessage" class="influencer-message" aria-live="polite"></div>
+          <div class="card-heading">
+            <h2 id="influencer-info-title">Seus dados principais</h2>
+            <p class="card-subtitle">Confira e compartilhe facilmente suas informações de cadastro.</p>
+          </div>
+          <div id="influencerDetails" class="info-grid"></div>
+          <div id="influencerMessage" class="message" aria-live="polite"></div>
         </section>
 
         <section class="card" aria-labelledby="influencer-sales-title">
-          <div class="sales-header">
-            <h2 id="influencer-sales-title">Acompanhe seu desempenho.</h2>
+          <div class="card-heading">
+            <h2 id="influencer-sales-title">Desempenho em vendas</h2>
+            <p class="card-subtitle">Veja o histórico de vendas registradas com seus cupons.</p>
           </div>
-          <div id="influencerSalesMessage" class="sales-message" aria-live="polite"></div>
+          <div class="sales-summary-wrapper">
+            <div id="influencerSalesSummary" class="summary"></div>
+            <div id="influencerSalesMessage" class="message" aria-live="polite"></div>
+          </div>
           <div class="table-wrapper">
             <table id="influencerSalesTable">
               <thead>
@@ -355,13 +47,8 @@
               <tbody></tbody>
             </table>
           </div>
-          <div id="influencerSalesSummary" class="summary"></div>
         </section>
       </main>
-
-      <div class="logout-wrapper">
-        <button type="button" data-action="logout" class="logout-button">Sair do painel</button>
-      </div>
     </div>
   </body>
 </html>

--- a/public/main.js
+++ b/public/main.js
@@ -81,6 +81,12 @@
     return currencyFormatter.format(Number.isFinite(number) ? number : 0);
   };
 
+  const integerFormatter = new Intl.NumberFormat('pt-BR', { maximumFractionDigits: 0 });
+  const formatInteger = (value) => {
+    const number = Number(value);
+    return integerFormatter.format(Number.isFinite(number) ? number : 0);
+  };
+
   const formatDateToBR = (value) => {
     if (!value) return '-';
     const iso = String(value).split('T')[0];
@@ -95,6 +101,93 @@
     const number = Number(value);
     if (!Number.isFinite(number)) return '-';
     return `${number.toFixed(2)}%`;
+  };
+
+  const createSummaryItemElement = ({ label, value, helper, icon = 'info' }) => {
+    const item = document.createElement('div');
+    item.className = 'summary-item';
+
+    const iconEl = document.createElement('span');
+    iconEl.className = `summary-icon summary-icon--${icon}`;
+    item.appendChild(iconEl);
+
+    const contentEl = document.createElement('div');
+    contentEl.className = 'summary-content';
+
+    const labelEl = document.createElement('span');
+    labelEl.className = 'summary-label';
+    labelEl.textContent = label;
+    contentEl.appendChild(labelEl);
+
+    const valueEl = document.createElement('strong');
+    valueEl.className = 'summary-value';
+    valueEl.textContent = value;
+    contentEl.appendChild(valueEl);
+
+    if (helper) {
+      const helperEl = document.createElement('span');
+      helperEl.className = 'summary-helper';
+      helperEl.textContent = helper;
+      contentEl.appendChild(helperEl);
+    }
+
+    item.appendChild(contentEl);
+    return item;
+  };
+
+  const renderSummaryMetrics = (container, metrics = []) => {
+    if (!container) return;
+    container.innerHTML = '';
+    if (!Array.isArray(metrics) || metrics.length === 0) {
+      return;
+    }
+    const fragment = document.createDocumentFragment();
+    metrics.forEach((metric) => {
+      fragment.appendChild(createSummaryItemElement(metric));
+    });
+    container.appendChild(fragment);
+  };
+
+  const buildSalesSummaryMetrics = (summary, totalSales = 0) => {
+    let safeTotalSales = Number(totalSales);
+    if (!Number.isFinite(safeTotalSales) || safeTotalSales < 0) {
+      safeTotalSales = 0;
+    }
+
+    const salesHelper =
+      safeTotalSales === 0
+        ? 'Nenhuma venda registrada ainda'
+        : safeTotalSales === 1
+        ? 'venda concluída'
+        : 'vendas concluídas';
+
+    const metrics = [
+      {
+        label: 'Pedidos registrados',
+        value: formatInteger(safeTotalSales),
+        helper: salesHelper,
+        icon: 'orders'
+      }
+    ];
+
+    if (summary) {
+      metrics.push(
+        {
+          label: 'Total em vendas',
+          value: formatCurrency(summary.total_net),
+          helper: 'Valor líquido acumulado',
+          icon: 'revenue'
+        },
+        {
+          label: 'Sua comissão',
+          value: formatCurrency(summary.total_commission),
+          helper: 'Estimativa atual',
+          icon: 'commission'
+        }
+      );
+    }
+
+    return metrics;
   };
 
   const session = {
@@ -1088,18 +1181,12 @@
       salesTableBody.appendChild(fragment);
     };
 
-    const renderSalesSummary = (summary) => {
-      if (!salesSummaryEl) return;
-      if (!summary) {
-        salesSummaryEl.textContent = '';
-        return;
-      }
-      salesSummaryEl.innerHTML = '';
-      const totalNet = document.createElement('span');
-      totalNet.textContent = `Total em vendas: ${formatCurrency(summary.total_net)}`;
-      const totalCommission = document.createElement('span');
-      totalCommission.textContent = `Sua comissão: ${formatCurrency(summary.total_commission)}`;
-      salesSummaryEl.append(totalNet, totalCommission);
+    const renderSalesSummary = (summary, { totalSales } = {}) => {
+      const metrics = buildSalesSummaryMetrics(
+        summary,
+        typeof totalSales === 'number' ? totalSales : Array.isArray(sales) ? sales.length : 0
+      );
+      renderSummaryMetrics(salesSummaryEl, metrics);
     };
 
     const updateImportConfirmState = () => {
@@ -1231,7 +1318,7 @@
       if (!influencerId) {
         sales = [];
         renderSalesTable();
-        renderSalesSummary(null);
+        renderSalesSummary(null, { totalSales: 0 });
         return;
       }
       if (showStatus) setMessage(messageEl, 'Carregando vendas...', 'info');
@@ -1241,13 +1328,13 @@
         renderSalesTable();
         try {
           const summary = await apiFetch(`/sales/summary/${influencerId}`);
-          renderSalesSummary(summary);
+          renderSalesSummary(summary, { totalSales: sales.length });
         } catch (summaryError) {
           if (summaryError.status === 401) {
             logout();
             return;
           }
-          renderSalesSummary(null);
+          renderSalesSummary(null, { totalSales: sales.length });
         }
         if (!sales.length) {
           if (showStatus) setMessage(messageEl, 'Nenhuma venda cadastrada para este cupom.', 'info');
@@ -1259,8 +1346,9 @@
           logout();
           return;
         }
-        renderSalesTable([]);
-        renderSalesSummary(null);
+        sales = [];
+        renderSalesTable();
+        renderSalesSummary(null, { totalSales: 0 });
         setMessage(messageEl, error.message || 'Nao foi possivel carregar as vendas.', 'error');
       }
     };
@@ -1296,7 +1384,7 @@
         currentSalesInfluencerId = null;
         sales = [];
         renderSalesTable();
-        renderSalesSummary(null);
+        renderSalesSummary(null, { totalSales: 0 });
         updateSaleComputedFields();
         setMessage(messageEl, 'Selecione um cupom para visualizar e registrar as vendas.', 'info');
         return;
@@ -1586,8 +1674,22 @@
     };
 
     const createValueElement = (value) => {
-      if (value && typeof value === 'object' && value.type === 'copy-link') {
-        return createCopyLinkElement(value);
+      if (value && typeof value === 'object') {
+        if (value.type === 'copy-link') {
+          return createCopyLinkElement(value);
+        }
+        if (value.type === 'link' && value.url) {
+          const anchor = document.createElement('a');
+          anchor.href = value.url;
+          anchor.className = 'detail-link';
+          anchor.classList.add('info-value');
+          anchor.textContent = value.label || value.url;
+          if (value.external !== false) {
+            anchor.target = '_blank';
+            anchor.rel = 'noopener noreferrer';
+          }
+          return anchor;
+        }
       }
       const el = document.createElement('span');
       el.className = 'info-value';
@@ -1595,11 +1697,52 @@
       return el;
     };
 
+    const instagramHandle = (data.instagram || '').trim();
+    const hasInstagram = instagramHandle && instagramHandle !== '-';
+    const instagramLabel = hasInstagram
+      ? instagramHandle.startsWith('@')
+        ? instagramHandle
+        : `@${instagramHandle}`
+      : data.instagram;
+    const instagramValue = hasInstagram
+      ? {
+          type: 'link',
+          url: `https://www.instagram.com/${instagramHandle.replace(/^@/, '')}`,
+          label: instagramLabel,
+          external: true
+        }
+      : data.instagram;
+
+    const emailValue =
+      data.email && data.email !== '-'
+        ? { type: 'link', url: `mailto:${data.email}`, label: data.email, external: false }
+        : data.email;
+
+    const contactDigits = digitOnly(data.contato);
+    const contactValue =
+      data.contato && data.contato !== '-' && contactDigits
+        ? { type: 'link', url: `tel:+55${contactDigits}`, label: data.contato, external: false }
+        : data.contato;
+
+    const loginEmailValue =
+      data.loginEmail && data.loginEmail !== '-'
+        ? { type: 'link', url: `mailto:${data.loginEmail}`, label: data.loginEmail, external: false }
+        : data.loginEmail;
+
+    const addressParts = [data.logradouro, data.numero].filter((part) => part && part !== '-');
+    const addressValue = addressParts.length ? addressParts.join(', ') : data.logradouro;
+
+    const locationParts = [data.cidade, data.estado].filter((part) => part && part !== '-');
+    const locationValue = locationParts.length ? locationParts.join(' / ') : '-';
+
     const items = [
       ['Nome', data.nome],
+      ['Instagram', instagramValue],
+      ['E-mail', emailValue],
+      ['Contato', contactValue],
       ['Cupom', data.cupom],
       [
-        'Link',
+        'Link de desconto',
         data.discountLink
           ? {
               type: 'copy-link',
@@ -1608,7 +1751,14 @@
               copyLabel: 'Copiar link'
             }
           : '-'
-      ]
+      ],
+      ['Comissão', data.commissionPercent],
+      ['Localização', locationValue],
+      ['Endereço', addressValue],
+      ['Complemento', data.complemento],
+      ['Bairro', data.bairro],
+      ['CEP', data.cep],
+      ['Login de acesso', loginEmailValue]
     ];
 
     const fragment = document.createDocumentFragment();
@@ -1667,10 +1817,16 @@
             ? formatCurrency(sale.net_value)
             : formatCurrency(sale.gross_value);
         const statusLabel = sale.status || sale.status_label || sale.statusLabel || 'Concluída';
-        const cells = [sale.date || '-', customerName, valueToDisplay, statusLabel];
-        cells.forEach((value) => {
+        const cells = [
+          { label: 'Data', value: sale.date || '-' },
+          { label: 'Cliente', value: customerName },
+          { label: 'Valor', value: valueToDisplay },
+          { label: 'Status', value: statusLabel }
+        ];
+        cells.forEach(({ label, value }) => {
           const td = document.createElement('td');
           td.textContent = value;
+          td.dataset.label = label;
           tr.appendChild(td);
         });
         fragment.appendChild(tr);
@@ -1678,41 +1834,33 @@
       salesTableBody.appendChild(fragment);
     };
 
-    const renderSalesSummary = (summary) => {
-      if (!salesSummaryEl) return;
-      if (!summary) {
-        salesSummaryEl.textContent = '';
-        return;
-      }
-      salesSummaryEl.innerHTML = '';
-      const totalNet = document.createElement('span');
-      totalNet.textContent = `Total em vendas: ${formatCurrency(summary.total_net)}`;
-      const totalCommission = document.createElement('span');
-      totalCommission.textContent = `Sua comissão: ${formatCurrency(summary.total_commission)}`;
-      salesSummaryEl.append(totalNet, totalCommission);
+    const renderSalesSummary = (summary, { totalSales = 0 } = {}) => {
+      renderSummaryMetrics(salesSummaryEl, buildSalesSummaryMetrics(summary, totalSales));
     };
 
     const loadInfluencerSales = async (influencerId) => {
       if (!influencerId) {
         renderSalesTable([]);
-        renderSalesSummary(null);
+        renderSalesSummary(null, { totalSales: 0 });
         return;
       }
       setMessage(salesMessageEl, 'Carregando vendas...', 'info');
       try {
         const salesData = await apiFetch(`/sales/${influencerId}`);
-        renderSalesTable(Array.isArray(salesData) ? salesData : []);
+        const rows = Array.isArray(salesData) ? salesData : [];
+        renderSalesTable(rows);
+        const totalSales = rows.length;
         try {
           const summaryData = await apiFetch(`/sales/summary/${influencerId}`);
-          renderSalesSummary(summaryData);
+          renderSalesSummary(summaryData, { totalSales });
         } catch (summaryError) {
           if (summaryError.status === 401) {
             logout();
             return;
           }
-          renderSalesSummary(null);
+          renderSalesSummary(null, { totalSales });
         }
-        if (!salesData?.length) {
+        if (!totalSales) {
           setMessage(salesMessageEl, '', '');
         } else {
           setMessage(salesMessageEl, 'Vendas atualizadas com sucesso.', 'success');
@@ -1724,7 +1872,7 @@
         }
         setMessage(salesMessageEl, error.message || 'Nao foi possivel carregar as vendas.', 'error');
         renderSalesTable([]);
-        renderSalesSummary(null);
+        renderSalesSummary(null, { totalSales: 0 });
       }
     };
 
@@ -1737,7 +1885,7 @@
           setMessage(messageEl, 'Nenhum registro associado ao seu usuario.', 'info');
           renderInfluencerDetails(detailsEl, null);
           renderSalesTable([]);
-          renderSalesSummary(null);
+          renderSalesSummary(null, { totalSales: 0 });
           return;
         }
         renderInfluencerDetails(detailsEl, formatInfluencerDetails(influencer));

--- a/public/style.css
+++ b/public/style.css
@@ -326,21 +326,121 @@ table tbody td:last-child {
 }
 
 .summary {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
-  padding: 16px;
-  border-radius: var(--radius-md);
-  background: rgba(251, 211, 219, 0.6);
-  border: 1px solid rgba(228, 68, 122, 0.22);
-  font-weight: 600;
-  color: var(--text-primary);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+  padding: 0;
+  margin: 0;
+  background: none;
+  border: none;
+  box-shadow: none;
 }
 
-.summary span {
+.summary:empty {
+  display: none;
+}
+
+.summary-item {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 16px;
+  padding: 18px 20px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(228, 68, 122, 0.2);
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.96), rgba(251, 211, 219, 0.88));
+  box-shadow: 0 14px 32px rgba(228, 68, 122, 0.12);
+}
+
+.summary-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(228, 68, 122, 0.22), rgba(228, 68, 122, 0.38));
+  display: grid;
+  place-items: center;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+}
+
+.summary-icon::before {
+  content: '';
+  width: 26px;
+  height: 26px;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+}
+
+.summary-icon--orders::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23ffffff' viewBox='0 0 24 24'%3E%3Cpath d='M7 7V6a5 5 0 0 1 10 0v1h3a1 1 0 0 1 .99 1.14l-1.5 10A2 2 0 0 1 17.52 20H6.48a2 2 0 0 1-1.97-1.86l-1.5-10A1 1 0 0 1 4 7h3zm2-1a3 3 0 0 1 6 0v1H9zm9.03 3H5.97l1.29 8.58a1 1 0 0 0 .99.84h9.5a1 1 0 0 0 .99-.84z'/%3E%3C/svg%3E");
+}
+
+.summary-icon--revenue::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23ffffff' viewBox='0 0 24 24'%3E%3Cpath d='M12 3c3.866 0 7 1.567 7 3.5S15.866 10 12 10s-7-1.567-7-3.5S8.134 3 12 3zm0 9c2.89 0 5.478-.86 6.734-2.165.176.29.266.6.266.915C19 12.433 15.866 14 12 14s-7-1.567-7-3.5c0-.315.09-.625.266-.915C6.522 11.14 9.11 12 12 12zm0 4c2.89 0 5.478-.86 6.734-2.165.176.29.266.6.266.915C19 16.433 15.866 18 12 18s-7-1.567-7-3.5c0-.315.09-.625.266-.915C6.522 15.14 9.11 16 12 16z'/%3E%3C/svg%3E");
+}
+
+.summary-icon--commission::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23ffffff' viewBox='0 0 24 24'%3E%3Cpath d='M12 3.25l2.146 4.35 4.804.7-3.475 3.387.82 4.786L12 14.77l-4.295 2.703.82-4.786-3.475-3.388 4.804-.7z'/%3E%3C/svg%3E");
+}
+
+.summary-icon--info::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23ffffff' viewBox='0 0 24 24'%3E%3Cpath d='M12 2a10 10 0 1 0 .001 20.001A10 10 0 0 0 12 2zm0 4a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5zm1.5 11.5h-3a1 1 0 0 1 0-2h.5v-3h-.5a1 1 0 1 1 0-2h2a1 1 0 0 1 1 1v4h.5a1 1 0 0 1 0 2z'/%3E%3C/svg%3E");
+}
+
+.summary-content {
+  display: grid;
+  gap: 4px;
+}
+
+.summary-label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--pink-strong);
+  font-weight: 700;
+}
+
+.summary-value {
+  font-size: clamp(1.45rem, 2.8vw, 1.75rem);
+  font-weight: 700;
+  color: var(--pink-strong);
+}
+
+.summary-helper {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.sales-summary-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.sales-summary-wrapper .message {
+  margin: 0;
+}
+
+@media (min-width: 992px) {
+  .sales-summary-wrapper {
+    flex-direction: row;
+    align-items: stretch;
+  }
+
+  .sales-summary-wrapper .summary {
+    flex: 1;
+    min-height: 100%;
+  }
+
+  .sales-summary-wrapper .message {
+    flex-basis: 280px;
+  }
+}
+
+@media (min-width: 1040px) {
+  .dashboard-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .influencers-list {
@@ -393,6 +493,250 @@ table tbody td:last-child {
 .details p {
   margin: 0;
   color: var(--text-secondary);
+}
+
+.message:empty {
+  display: none;
+}
+
+.dashboard-grid {
+  display: grid;
+  gap: clamp(24px, 4vw, 32px);
+}
+
+.card-heading {
+  display: grid;
+  gap: 8px;
+  text-align: center;
+}
+
+.card-subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.info-item {
+  display: grid;
+  gap: 8px;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(251, 211, 219, 0.82));
+  border: 1px solid rgba(228, 68, 122, 0.2);
+  box-shadow: 0 16px 32px rgba(228, 68, 122, 0.12);
+}
+
+.info-label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--pink-strong);
+}
+
+.info-value {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.info-value.detail-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.detail-link {
+  color: var(--pink-strong);
+  font-weight: 600;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(228, 68, 122, 0.4);
+  padding-bottom: 2px;
+  transition: color var(--transition), border-color var(--transition);
+}
+
+.detail-link:hover,
+.detail-link:focus {
+  color: var(--pink-medium);
+  border-color: rgba(240, 121, 153, 0.6);
+  outline: none;
+}
+
+button.copy-button {
+  background: rgba(228, 68, 122, 0.14);
+  color: var(--pink-strong);
+  border: 1px solid rgba(228, 68, 122, 0.28);
+  box-shadow: none;
+  font-size: 0.9rem;
+  padding: 8px 18px;
+  border-radius: 999px;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+button.copy-button:hover,
+button.copy-button:focus {
+  transform: translateY(-1px);
+  background: rgba(228, 68, 122, 0.22);
+  box-shadow: 0 10px 20px rgba(228, 68, 122, 0.18);
+  outline: none;
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: clamp(16px, 6vw, 32px) clamp(14px, 5vw, 28px);
+  }
+
+  header {
+    text-align: left;
+    justify-items: stretch;
+  }
+
+  header button {
+    justify-self: stretch;
+    width: 100%;
+  }
+
+  .card {
+    padding: clamp(20px, 6vw, 28px);
+  }
+
+  .summary {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .summary-item {
+    padding: 16px 18px;
+  }
+
+  .summary-icon {
+    width: 48px;
+    height: 48px;
+  }
+
+  .summary-icon::before {
+    width: 24px;
+    height: 24px;
+  }
+
+  .summary-value {
+    font-size: 1.35rem;
+  }
+
+  .info-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .sales-summary-wrapper {
+    margin-bottom: 12px;
+  }
+
+  .summary {
+    gap: 14px;
+  }
+
+  .summary-item {
+    padding: 14px 16px;
+  }
+
+  .summary-value {
+    font-size: 1.28rem;
+  }
+
+  .summary-helper {
+    font-size: 0.85rem;
+  }
+
+  .table-wrapper {
+    overflow: visible;
+    border: none;
+    background: transparent;
+    box-shadow: none;
+    padding: 0;
+  }
+
+  table {
+    min-width: 0;
+    border: none;
+  }
+
+  table thead {
+    display: none;
+  }
+
+  table tbody {
+    display: grid;
+    gap: 14px;
+  }
+
+  table tbody tr {
+    display: grid;
+    gap: 10px;
+    padding: 16px 18px;
+    border-radius: var(--radius-md);
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(251, 211, 219, 0.9));
+    box-shadow: 0 14px 30px rgba(228, 68, 122, 0.14);
+  }
+
+  table tbody tr:nth-child(even),
+  table tbody tr:nth-child(odd),
+  table tbody tr:hover {
+    background: none;
+  }
+
+  table tbody td {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 0;
+    border: none;
+    font-size: 0.94rem;
+    color: var(--text-secondary);
+  }
+
+  table tbody td::before {
+    content: attr(data-label);
+    font-weight: 700;
+    color: var(--text-primary);
+    font-size: 0.92rem;
+  }
+
+  table tbody td:last-child {
+    white-space: normal;
+  }
+
+  .message {
+    font-size: 0.9rem;
+  }
+}
+
+button.copy-button.copied {
+  background: rgba(52, 211, 153, 0.18);
+  border-color: rgba(16, 185, 129, 0.32);
+  color: #0f5132;
+}
+
+button.copy-button.error {
+  background: rgba(248, 113, 113, 0.16);
+  border-color: rgba(220, 38, 38, 0.32);
+  color: #7f1d1d;
+}
+
+@media (max-width: 600px) {
+  .info-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 900px) {
@@ -453,10 +797,6 @@ table tbody td:last-child {
 
 body[data-page='master-create'] #createInfluencerForm[data-mode='edit'] .credentials-group {
   display: none;
-}
-
-.summary strong {
-  color: var(--pink-strong);
 }
 
 /* Login page adjustments */


### PR DESCRIPTION
## Summary
- adiciona utilitários para montar métricas de resumo com ícones e aplica o padrão aos painéis master e influenciadora
- amplia o grid de informações da influenciadora com contatos, localização e links acionáveis
- renova o estilo do resumo com cartões ilustrados e ajustes responsivos

## Testing
- npm test *(falha: dependência better-sqlite3 com header ELF inválido no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68e695ba44948323ba61fc4061d4a49f