### PR TITLE
Add influencer dashboard copy button and summary

### DIFF
--- a/public/influencer.html
+++ b/public/influencer.html
@@ -4,364 +4,43 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Painel Influenciadora | HidraPink</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
+    <link rel="stylesheet" href="style.css" />
     <script defer src="main.js"></script>
-    <style>
-      :root {
-        --pink-strong: #e4447a;
-        --pink-medium: #f07999;
-        --pink-light: #fbd3db;
-        --text-color: #361725;
-        --shadow: 0 26px 60px rgba(228, 68, 122, 0.22);
-      }
-
-      * {
-        box-sizing: border-box;
-      }
-
-      body {
-        margin: 0;
-        min-height: 100vh;
-        font-family: 'Montserrat', sans-serif;
-        background: #fff;
-        background-image: radial-gradient(circle at top right, rgba(228, 68, 122, 0.14), transparent 60%),
-          radial-gradient(circle at bottom left, rgba(240, 121, 153, 0.18), transparent 58%),
-          linear-gradient(180deg, rgba(251, 211, 219, 0.28), rgba(255, 255, 255, 0.4));
-        color: var(--text-color);
-        display: flex;
-        justify-content: center;
-        align-items: flex-start;
-        padding: 48px 16px 56px;
-      }
-
-      .pinklover-container {
-        width: 100%;
-        max-width: 600px;
-        display: flex;
-        flex-direction: column;
-        gap: 36px;
-      }
-
-      .pinklover-content {
-        display: flex;
-        flex-direction: column;
-        gap: 32px;
-      }
-
-      .pinklover-banner {
-        background: linear-gradient(115deg, var(--pink-strong), var(--pink-medium));
-        color: #ffffff;
-        text-align: center;
-        font-weight: 700;
-        font-size: 1.5rem;
-        padding: 18px 24px;
-        border-radius: 22px;
-        box-shadow: var(--shadow);
-        margin: 0;
-        letter-spacing: 0.02em;
-      }
-
-      .card {
-        background: linear-gradient(135deg, var(--pink-strong), var(--pink-medium));
-        border-radius: 26px;
-        padding: 28px 28px 32px;
-        box-shadow: var(--shadow);
-        color: var(--text-color);
-        position: relative;
-        overflow: hidden;
-        z-index: 0;
-      }
-
-      .card::before {
-        content: '';
-        position: absolute;
-        inset: 1px;
-        border-radius: 24px;
-        border: 1px solid rgba(255, 255, 255, 0.32);
-        pointer-events: none;
-        z-index: 0;
-      }
-
-      .card > * {
-        position: relative;
-        z-index: 1;
-      }
-
-      .card h2 {
-        margin: 0 0 18px;
-        font-size: 1.25rem;
-        font-weight: 700;
-        text-align: center;
-      }
-
-      .logout-wrapper {
-        display: flex;
-        justify-content: flex-end;
-        margin-top: 8px;
-      }
-
-      .logout-button {
-        margin: 0;
-        background: #ffffff;
-        color: var(--pink-strong);
-        border: none;
-        border-radius: 999px;
-        padding: 12px 28px;
-        font-weight: 700;
-        font-size: 0.95rem;
-        cursor: pointer;
-        transition: transform 0.2s ease, box-shadow 0.2s ease;
-        box-shadow: 0 12px 24px rgba(255, 255, 255, 0.25);
-      }
-
-      .logout-button:hover,
-      .logout-button:focus {
-        transform: translateY(-1px);
-        box-shadow: 0 16px 30px rgba(255, 255, 255, 0.35);
-        outline: none;
-      }
-
-      .influencer-info {
-        display: flex;
-        flex-direction: column;
-        gap: 16px;
-      }
-
-      .info-item {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 6px;
-      }
-
-      .info-label {
-        font-weight: 700;
-        font-size: 0.95rem;
-      }
-
-      .info-value {
-        font-weight: 500;
-        font-size: 1rem;
-        word-break: break-word;
-      }
-
-      .detail-actions {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 8px;
-      }
-
-      .copy-button {
-        background: rgba(255, 255, 255, 0.28);
-        color: var(--text-color);
-        border: none;
-        border-radius: 999px;
-        padding: 8px 16px;
-        font-weight: 600;
-        font-size: 0.85rem;
-        cursor: pointer;
-        transition: transform 0.2s ease, box-shadow 0.2s ease;
-      }
-
-      .copy-button:hover,
-      .copy-button:focus {
-        transform: translateY(-1px);
-        box-shadow: 0 6px 18px rgba(45, 13, 27, 0.15);
-        outline: none;
-      }
-
-      .copy-button.copied {
-        background: rgba(255, 255, 255, 0.48);
-      }
-
-      .copy-button.error {
-        background: rgba(255, 255, 255, 0.22);
-      }
-
-      .influencer-message {
-        margin-top: 16px;
-        font-size: 0.95rem;
-        text-align: center;
-      }
-
-      .sales-header {
-        display: flex;
-        flex-direction: column;
-        gap: 8px;
-        margin-bottom: 18px;
-      }
-
-      .table-wrapper {
-        overflow-x: auto;
-        background: rgba(255, 255, 255, 0.38);
-        border-radius: 20px;
-      }
-
-      table {
-        width: 100%;
-        border-collapse: collapse;
-        font-size: 0.95rem;
-        min-width: 460px;
-      }
-
-      th,
-      td {
-        padding: 14px 16px;
-        text-align: left;
-      }
-
-      th {
-        font-weight: 700;
-        text-transform: uppercase;
-        font-size: 0.8rem;
-        letter-spacing: 0.05em;
-        color: var(--text-color);
-        background: rgba(255, 255, 255, 0.7);
-      }
-
-      tbody tr:nth-child(odd) {
-        background: rgba(251, 211, 219, 0.45);
-      }
-
-      tbody tr:nth-child(even) {
-        background: rgba(255, 255, 255, 0.9);
-      }
-
-      tbody tr:hover {
-        background: rgba(240, 121, 153, 0.2);
-      }
-
-      td {
-        font-weight: 500;
-      }
-
-      td.empty {
-        text-align: center;
-        font-weight: 600;
-        padding: 24px 16px;
-      }
-
-      .sales-message,
-      .influencer-message {
-        margin: 16px 0 0;
-        text-align: center;
-        font-weight: 500;
-      }
-
-      .sales-message:empty,
-      .influencer-message:empty {
-        display: none;
-        margin: 0;
-      }
-
-      .influencer-message[data-type='success'],
-      .sales-message[data-type='success'] {
-        color: #0f5132;
-      }
-
-      .influencer-message[data-type='error'],
-      .sales-message[data-type='error'] {
-        color: #7a1634;
-      }
-
-      .influencer-message[data-type='info'],
-      .sales-message[data-type='info'] {
-        color: var(--text-color);
-        opacity: 0.85;
-      }
-
-      .summary {
-        margin-top: 20px;
-        display: flex;
-        flex-direction: column;
-        gap: 6px;
-        text-align: center;
-        font-weight: 600;
-      }
-
-      .summary span {
-        display: block;
-        padding: 10px 18px;
-        border-radius: 999px;
-        background: rgba(251, 211, 219, 0.55);
-      }
-
-      a.detail-link {
-        color: inherit;
-        font-weight: 600;
-        text-decoration: underline;
-      }
-
-      @media (max-width: 768px) {
-        body {
-          padding: 40px 16px 48px;
-        }
-
-        .pinklover-container {
-          gap: 30px;
-        }
-      }
-
-      @media (max-width: 480px) {
-        body {
-          padding: 32px 12px 40px;
-        }
-
-        .pinklover-content {
-          gap: 26px;
-        }
-
-        .card {
-          padding: 22px 20px 26px;
-        }
-
-        table {
-          min-width: 320px;
-        }
-      }
-    </style>
   </head>
   <body data-page="influencer">
-    <div class="pinklover-container" id="influencerPage">
-      <header class="pinklover-banner">Bem vinda, Pinklover.</header>
+    <div class="container" id="influencerPage">
+      <header class="page-hero influencer-hero">
+        <h1 id="influencerGreeting">Bem vinda, Pinklover.</h1>
+      </header>
 
-      <main class="pinklover-content">
-        <section class="card" aria-labelledby="influencer-info-title">
-          <h2 id="influencer-info-title">Suas informações</h2>
-          <div id="influencerDetails" class="influencer-info"></div>
-          <div id="influencerMessage" class="influencer-message" aria-live="polite"></div>
+      <main class="dashboard-grid influencer-layout">
+        <section class="card influencer-details-card" aria-labelledby="influencer-info-title">
+          <h2 id="influencer-info-title" class="visually-hidden">Dados da influenciadora</h2>
+          <div id="influencerDetails" class="info-grid" aria-live="polite"></div>
+          <div class="card-actions">
+            <button type="button" class="button-logout" data-action="logout">Sair</button>
+          </div>
         </section>
 
-        <section class="card" aria-labelledby="influencer-sales-title">
-          <div class="sales-header">
-            <h2 id="influencer-sales-title">Acompanhe seu desempenho.</h2>
-          </div>
-          <div id="influencerSalesMessage" class="sales-message" aria-live="polite"></div>
+        <section class="card influencer-history-card" aria-labelledby="influencer-sales-title">
+          <h2 id="influencer-sales-title">Acompanhe seu desempenho.</h2>
+          <div id="influencerSalesMessage" class="message" aria-live="polite"></div>
+          <div id="influencerSalesSummary" class="sales-summary-inline" aria-live="polite"></div>
           <div class="table-wrapper">
             <table id="influencerSalesTable">
               <thead>
                 <tr>
+                  <th>Número do pedido</th>
                   <th>Data</th>
-                  <th>Cliente</th>
-                  <th>Valor</th>
-                  <th>Status</th>
+                  <th>Valor líquido</th>
+                  <th>Comissão</th>
                 </tr>
               </thead>
               <tbody></tbody>
             </table>
           </div>
-          <div id="influencerSalesSummary" class="summary"></div>
         </section>
       </main>
-
-      <div class="logout-wrapper">
-        <button type="button" data-action="logout" class="logout-button">Sair do painel</button>
-      </div>
     </div>
   </body>
 </html>

--- a/public/main.js
+++ b/public/main.js
@@ -76,10 +76,23 @@
   };
 
   const currencyFormatter = new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' });
-  const formatCurrency = (value) => {
-    const number = Number(value);
-    return currencyFormatter.format(Number.isFinite(number) ? number : 0);
+
+  const parseToNumber = (value) => {
+    if (typeof value === 'string') {
+      const normalized = value.replace(/\./g, '').replace(',', '.');
+      const parsed = Number(normalized);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
   };
+
+  const formatCurrency = (value) => currencyFormatter.format(parseToNumber(value));
+
+  const integerFormatter = new Intl.NumberFormat('pt-BR', { maximumFractionDigits: 0 });
+  const formatInteger = (value) => integerFormatter.format(parseToNumber(value));
 
   const formatDateToBR = (value) => {
     if (!value) return '-';
@@ -95,6 +108,93 @@
     const number = Number(value);
     if (!Number.isFinite(number)) return '-';
     return `${number.toFixed(2)}%`;
+  };
+
+  const createSummaryItemElement = ({ label, value, helper, icon = 'info' }) => {
+    const item = document.createElement('div');
+    item.className = 'summary-item';
+
+    const iconEl = document.createElement('span');
+    iconEl.className = `summary-icon summary-icon--${icon}`;
+    item.appendChild(iconEl);
+
+    const contentEl = document.createElement('div');
+    contentEl.className = 'summary-content';
+
+    const labelEl = document.createElement('span');
+    labelEl.className = 'summary-label';
+    labelEl.textContent = label;
+    contentEl.appendChild(labelEl);
+
+    const valueEl = document.createElement('strong');
+    valueEl.className = 'summary-value';
+    valueEl.textContent = value;
+    contentEl.appendChild(valueEl);
+
+    if (helper) {
+      const helperEl = document.createElement('span');
+      helperEl.className = 'summary-helper';
+      helperEl.textContent = helper;
+      contentEl.appendChild(helperEl);
+    }
+
+    item.appendChild(contentEl);
+    return item;
+  };
+
+  const renderSummaryMetrics = (container, metrics = []) => {
+    if (!container) return;
+    container.innerHTML = '';
+    if (!Array.isArray(metrics) || metrics.length === 0) {
+      return;
+    }
+    const fragment = document.createDocumentFragment();
+    metrics.forEach((metric) => {
+      fragment.appendChild(createSummaryItemElement(metric));
+    });
+    container.appendChild(fragment);
+  };
+
+  const buildSalesSummaryMetrics = (summary, totalSales = 0) => {
+    let safeTotalSales = Number(totalSales);
+    if (!Number.isFinite(safeTotalSales) || safeTotalSales < 0) {
+      safeTotalSales = 0;
+    }
+
+    const salesHelper =
+      safeTotalSales === 0
+        ? 'Nenhuma venda registrada ainda'
+        : safeTotalSales === 1
+        ? 'venda concluída'
+        : 'vendas concluídas';
+
+    const metrics = [
+      {
+        label: 'Pedidos registrados',
+        value: formatInteger(safeTotalSales),
+        helper: salesHelper,
+        icon: 'orders'
+      }
+    ];
+
+    if (summary) {
+      metrics.push(
+        {
+          label: 'Total em vendas',
+          value: formatCurrency(summary.total_net),
+          helper: 'Valor líquido acumulado',
+          icon: 'revenue'
+        },
+        {
+          label: 'Sua comissão',
+          value: formatCurrency(summary.total_commission),
+          helper: 'Estimativa atual',
+          icon: 'commission'
+        }
+      );
+    }
+
+    return metrics;
   };
 
   const session = {
@@ -368,20 +468,8 @@
     const discountLink = coupon ? `https://www.hidrapink.com.br/discount/${encodeURIComponent(coupon)}` : '';
     return {
       nome: data.nome || '-',
-      instagram: data.instagram || '-',
-      email: data.email || '-',
-      contato: data.contato || '-',
       cupom: coupon || '-',
-      commissionPercent: data.commission_rate != null ? formatPercentage(data.commission_rate) : '-',
-      cep: data.cep || '-',
-      logradouro: data.logradouro || '-',
-      numero: data.numero || '-',
-      complemento: data.complemento || '-',
-      bairro: data.bairro || '-',
-      cidade: data.cidade || '-',
-      estado: data.estado || '-',
-      loginEmail: data.login_email || data.loginEmail || '-',
-      discountLink
+      discountLink: discountLink || '-'
     };
   };
 
@@ -1088,18 +1176,12 @@
       salesTableBody.appendChild(fragment);
     };
 
-    const renderSalesSummary = (summary) => {
-      if (!salesSummaryEl) return;
-      if (!summary) {
-        salesSummaryEl.textContent = '';
-        return;
-      }
-      salesSummaryEl.innerHTML = '';
-      const totalNet = document.createElement('span');
-      totalNet.textContent = `Total em vendas: ${formatCurrency(summary.total_net)}`;
-      const totalCommission = document.createElement('span');
-      totalCommission.textContent = `Sua comissão: ${formatCurrency(summary.total_commission)}`;
-      salesSummaryEl.append(totalNet, totalCommission);
+    const renderSalesSummary = (summary, { totalSales } = {}) => {
+      const metrics = buildSalesSummaryMetrics(
+        summary,
+        typeof totalSales === 'number' ? totalSales : Array.isArray(sales) ? sales.length : 0
+      );
+      renderSummaryMetrics(salesSummaryEl, metrics);
     };
 
     const updateImportConfirmState = () => {
@@ -1231,7 +1313,7 @@
       if (!influencerId) {
         sales = [];
         renderSalesTable();
-        renderSalesSummary(null);
+        renderSalesSummary(null, { totalSales: 0 });
         return;
       }
       if (showStatus) setMessage(messageEl, 'Carregando vendas...', 'info');
@@ -1241,13 +1323,13 @@
         renderSalesTable();
         try {
           const summary = await apiFetch(`/sales/summary/${influencerId}`);
-          renderSalesSummary(summary);
+          renderSalesSummary(summary, { totalSales: sales.length });
         } catch (summaryError) {
           if (summaryError.status === 401) {
             logout();
             return;
           }
-          renderSalesSummary(null);
+          renderSalesSummary(null, { totalSales: sales.length });
         }
         if (!sales.length) {
           if (showStatus) setMessage(messageEl, 'Nenhuma venda cadastrada para este cupom.', 'info');
@@ -1259,8 +1341,9 @@
           logout();
           return;
         }
-        renderSalesTable([]);
-        renderSalesSummary(null);
+        sales = [];
+        renderSalesTable();
+        renderSalesSummary(null, { totalSales: 0 });
         setMessage(messageEl, error.message || 'Nao foi possivel carregar as vendas.', 'error');
       }
     };
@@ -1296,7 +1379,7 @@
         currentSalesInfluencerId = null;
         sales = [];
         renderSalesTable();
-        renderSalesSummary(null);
+        renderSalesSummary(null, { totalSales: 0 });
         updateSaleComputedFields();
         setMessage(messageEl, 'Selecione um cupom para visualizar e registrar as vendas.', 'info');
         return;
@@ -1540,54 +1623,20 @@
       return;
     }
 
-    const createCopyLinkElement = (value) => {
-      const wrapper = document.createElement('div');
-      wrapper.className = 'info-value detail-actions';
-      if (!value?.url) {
-        wrapper.textContent = '-';
-        return wrapper;
-      }
-
-      const linkLabel = value.label || value.url;
-      const anchor = document.createElement('a');
-      anchor.href = value.url;
-      anchor.target = '_blank';
-      anchor.rel = 'noopener noreferrer';
-      anchor.className = 'detail-link';
-      anchor.textContent = linkLabel;
-      wrapper.appendChild(anchor);
-
-      const copyBtn = document.createElement('button');
-      copyBtn.type = 'button';
-      copyBtn.className = 'copy-button';
-      const defaultCopyLabel = value.copyLabel || 'Copiar link';
-      copyBtn.textContent = defaultCopyLabel;
-      const successLabel = value.successLabel || 'Copiado!';
-      const errorLabel = value.errorLabel || 'Tente novamente';
-
-      copyBtn.addEventListener('click', async () => {
-        try {
-          await copyTextToClipboard(value.url);
-          copyBtn.textContent = successLabel;
-          copyBtn.classList.add('copied');
-        } catch (error) {
-          console.error(error);
-          copyBtn.textContent = errorLabel;
-          copyBtn.classList.add('error');
-        }
-        window.setTimeout(() => {
-          copyBtn.textContent = defaultCopyLabel;
-          copyBtn.classList.remove('copied', 'error');
-        }, 2000);
-      });
-
-      wrapper.appendChild(copyBtn);
-      return wrapper;
-    };
-
     const createValueElement = (value) => {
-      if (value && typeof value === 'object' && value.type === 'copy-link') {
-        return createCopyLinkElement(value);
+      if (value && typeof value === 'object') {
+        if (value.type === 'link' && value.url) {
+          const anchor = document.createElement('a');
+          anchor.href = value.url;
+          anchor.className = 'detail-link';
+          anchor.classList.add('info-value');
+          anchor.textContent = value.label || value.url;
+          if (value.external !== false) {
+            anchor.target = '_blank';
+            anchor.rel = 'noopener noreferrer';
+          }
+          return anchor;
+        }
       }
       const el = document.createElement('span');
       el.className = 'info-value';
@@ -1596,33 +1645,83 @@
     };
 
     const items = [
-      ['Nome', data.nome],
-      ['Cupom', data.cupom],
-      [
-        'Link',
-        data.discountLink
-          ? {
-              type: 'copy-link',
-              url: data.discountLink,
-              label: data.discountLink,
-              copyLabel: 'Copiar link'
-            }
-          : '-'
-      ]
+      {
+        key: 'nome',
+        label: 'Nome',
+        value: data.nome
+      },
+      {
+        key: 'cupom',
+        label: 'Cupom',
+        value: data.cupom
+      },
+      {
+        key: 'link',
+        label: 'Link',
+        value:
+          data.discountLink && data.discountLink !== '-'
+            ? {
+                type: 'link',
+                url: data.discountLink,
+                label: data.discountLink
+              }
+            : '-'
+      }
     ];
 
     const fragment = document.createDocumentFragment();
 
-    items.forEach(([label, value]) => {
+    items.forEach(({ key, label, value }) => {
       const item = document.createElement('div');
       item.className = 'info-item';
+      if (key) {
+        item.dataset.field = key;
+      }
 
       const labelEl = document.createElement('span');
       labelEl.className = 'info-label';
       labelEl.textContent = `${label}:`;
       item.appendChild(labelEl);
 
-      const valueEl = createValueElement(value);
+      let valueEl = null;
+      if (key === 'link' && value && typeof value === 'object' && value.url) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'info-value detail-actions';
+
+        const linkEl = createValueElement(value);
+        if (linkEl) {
+          wrapper.appendChild(linkEl);
+        }
+
+        const copyButton = document.createElement('button');
+        copyButton.type = 'button';
+        copyButton.className = 'copy-button';
+        const defaultCopyLabel = 'Copiar';
+        copyButton.textContent = defaultCopyLabel;
+        copyButton.addEventListener('click', async () => {
+          try {
+            await copyTextToClipboard(value.url);
+            copyButton.textContent = 'Copiado!';
+            copyButton.classList.remove('error');
+            copyButton.classList.add('copied');
+          } catch (error) {
+            copyButton.textContent = 'Erro ao copiar';
+            copyButton.classList.remove('copied');
+            copyButton.classList.add('error');
+          }
+          window.setTimeout(() => {
+            copyButton.textContent = defaultCopyLabel;
+            copyButton.classList.remove('copied');
+            copyButton.classList.remove('error');
+          }, 2000);
+        });
+        wrapper.appendChild(copyButton);
+
+        valueEl = wrapper;
+      } else {
+        valueEl = createValueElement(value);
+      }
+
       if (valueEl) {
         item.appendChild(valueEl);
       }
@@ -1633,20 +1732,77 @@
     container.appendChild(fragment);
   };
 
+  const renderInfluencerStatus = (container, message) => {
+    if (!container) return;
+    container.innerHTML = '';
+    if (!message) return;
+    const status = document.createElement('p');
+    status.className = 'info-status';
+    status.textContent = message;
+    container.appendChild(status);
+  };
+
   const initInfluencerPage = () => {
     if (!ensureAuth()) return;
     attachLogoutButtons();
 
     const detailsEl = document.getElementById('influencerDetails');
-    const messageEl = document.getElementById('influencerMessage');
+    const greetingEl = document.getElementById('influencerGreeting');
 
     const salesMessageEl = document.getElementById('influencerSalesMessage');
-    const salesTableBody = document.querySelector('#influencerSalesTable tbody');
     const salesSummaryEl = document.getElementById('influencerSalesSummary');
+    const salesTableBody = document.querySelector('#influencerSalesTable tbody');
+
+    const renderSalesSummary = (rows) => {
+      if (!salesSummaryEl) return;
+      salesSummaryEl.innerHTML = '';
+      if (!Array.isArray(rows) || rows.length === 0) {
+        return;
+      }
+
+      const totalOrders = rows.length;
+      const totalCommission = rows.reduce((sum, sale) => {
+        const candidates = [
+          sale.commission,
+          sale.commission_value,
+          sale.valor_comissao,
+          sale.comissao,
+          sale.commissionValue,
+          sale.commissionAmount
+        ];
+        const commissionValue = candidates.find((candidate) => candidate != null && candidate !== '');
+        return sum + parseToNumber(commissionValue);
+      }, 0);
+
+      const fragment = document.createDocumentFragment();
+
+      const ordersMetric = document.createElement('div');
+      ordersMetric.className = 'sales-summary-metric';
+      const ordersLabel = document.createElement('span');
+      ordersLabel.textContent = 'Quantidade de vendas';
+      const ordersValue = document.createElement('strong');
+      ordersValue.textContent = formatInteger(totalOrders);
+      ordersMetric.appendChild(ordersLabel);
+      ordersMetric.appendChild(ordersValue);
+      fragment.appendChild(ordersMetric);
+
+      const commissionMetric = document.createElement('div');
+      commissionMetric.className = 'sales-summary-metric';
+      const commissionLabel = document.createElement('span');
+      commissionLabel.textContent = 'Total de comissão';
+      const commissionValueEl = document.createElement('strong');
+      commissionValueEl.textContent = formatCurrency(totalCommission);
+      commissionMetric.appendChild(commissionLabel);
+      commissionMetric.appendChild(commissionValueEl);
+      fragment.appendChild(commissionMetric);
+
+      salesSummaryEl.appendChild(fragment);
+    };
 
     const renderSalesTable = (rows) => {
       if (!salesTableBody) return;
       salesTableBody.innerHTML = '';
+      renderSalesSummary(rows);
       if (!Array.isArray(rows) || rows.length === 0) {
         const emptyRow = document.createElement('tr');
         const emptyCell = document.createElement('td');
@@ -1660,17 +1816,66 @@
       const fragment = document.createDocumentFragment();
       rows.forEach((sale) => {
         const tr = document.createElement('tr');
-        const customerName =
-          sale.customer_name || sale.cliente || sale.customer || sale.client_name || sale.client || '-';
-        const valueToDisplay =
-          sale.net_value != null && sale.net_value !== ''
-            ? formatCurrency(sale.net_value)
-            : formatCurrency(sale.gross_value);
-        const statusLabel = sale.status || sale.status_label || sale.statusLabel || 'Concluída';
-        const cells = [sale.date || '-', customerName, valueToDisplay, statusLabel];
-        cells.forEach((value) => {
+        const orderCandidates = [
+          sale.order_number,
+          sale.orderNumber,
+          sale.numero_pedido,
+          sale.numeroPedido,
+          sale.order,
+          sale.pedido,
+          sale.id
+        ];
+        const orderValue = orderCandidates.find((candidate) => candidate != null && candidate !== '');
+        const orderDisplay = orderValue != null && orderValue !== '' ? String(orderValue) : '-';
+
+        const dateCandidates = [
+          sale.date,
+          sale.order_date,
+          sale.data,
+          sale.created_at,
+          sale.createdAt,
+          sale.sale_date
+        ];
+        const rawDate = dateCandidates.find((candidate) => candidate != null && candidate !== '');
+        const dateDisplay = rawDate ? formatDateToBR(rawDate) : '-';
+
+        const netCandidates = [
+          sale.net_value,
+          sale.netValue,
+          sale.valor_liquido,
+          sale.valorLiquidado,
+          sale.net,
+          sale.total_liquido,
+          sale.valor,
+          sale.value,
+          sale.amount,
+          sale.total,
+          sale.gross_value
+        ];
+        const netRaw = netCandidates.find((candidate) => candidate != null && candidate !== '');
+        const netDisplay = netRaw != null && netRaw !== '' ? formatCurrency(netRaw) : '-';
+
+        const commissionCandidates = [
+          sale.commission,
+          sale.commission_value,
+          sale.valor_comissao,
+          sale.comissao,
+          sale.commissionValue,
+          sale.commissionAmount
+        ];
+        const commissionRaw = commissionCandidates.find((candidate) => candidate != null && candidate !== '');
+        const commissionDisplay = commissionRaw != null && commissionRaw !== '' ? formatCurrency(commissionRaw) : '-';
+
+        const cells = [
+          { label: 'Número do pedido', value: orderDisplay },
+          { label: 'Data', value: dateDisplay },
+          { label: 'Valor líquido', value: netDisplay },
+          { label: 'Comissão', value: commissionDisplay }
+        ];
+        cells.forEach(({ label, value }) => {
           const td = document.createElement('td');
           td.textContent = value;
+          td.dataset.label = label;
           tr.appendChild(td);
         });
         fragment.appendChild(tr);
@@ -1678,45 +1883,18 @@
       salesTableBody.appendChild(fragment);
     };
 
-    const renderSalesSummary = (summary) => {
-      if (!salesSummaryEl) return;
-      if (!summary) {
-        salesSummaryEl.textContent = '';
-        return;
-      }
-      salesSummaryEl.innerHTML = '';
-      const totalNet = document.createElement('span');
-      totalNet.textContent = `Total em vendas: ${formatCurrency(summary.total_net)}`;
-      const totalCommission = document.createElement('span');
-      totalCommission.textContent = `Sua comissão: ${formatCurrency(summary.total_commission)}`;
-      salesSummaryEl.append(totalNet, totalCommission);
-    };
-
     const loadInfluencerSales = async (influencerId) => {
       if (!influencerId) {
         renderSalesTable([]);
-        renderSalesSummary(null);
+        setMessage(salesMessageEl, '', '');
         return;
       }
       setMessage(salesMessageEl, 'Carregando vendas...', 'info');
       try {
         const salesData = await apiFetch(`/sales/${influencerId}`);
-        renderSalesTable(Array.isArray(salesData) ? salesData : []);
-        try {
-          const summaryData = await apiFetch(`/sales/summary/${influencerId}`);
-          renderSalesSummary(summaryData);
-        } catch (summaryError) {
-          if (summaryError.status === 401) {
-            logout();
-            return;
-          }
-          renderSalesSummary(null);
-        }
-        if (!salesData?.length) {
-          setMessage(salesMessageEl, '', '');
-        } else {
-          setMessage(salesMessageEl, 'Vendas atualizadas com sucesso.', 'success');
-        }
+        const rows = Array.isArray(salesData) ? salesData : [];
+        renderSalesTable(rows);
+        setMessage(salesMessageEl, '', '');
       } catch (error) {
         if (error.status === 401) {
           logout();
@@ -1724,31 +1902,38 @@
         }
         setMessage(salesMessageEl, error.message || 'Nao foi possivel carregar as vendas.', 'error');
         renderSalesTable([]);
-        renderSalesSummary(null);
       }
     };
 
     const loadInfluencer = async () => {
-      setMessage(messageEl, 'Carregando dados...', 'info');
+      renderInfluencerStatus(detailsEl, 'Carregando dados...');
       try {
         const data = await apiFetch('/influenciadoras');
         const influencer = Array.isArray(data) ? data[0] : null;
         if (!influencer) {
-          setMessage(messageEl, 'Nenhum registro associado ao seu usuario.', 'info');
-          renderInfluencerDetails(detailsEl, null);
+          renderInfluencerStatus(detailsEl, 'Nenhum registro associado ao seu usuario.');
           renderSalesTable([]);
-          renderSalesSummary(null);
+          setMessage(salesMessageEl, '', '');
+          if (greetingEl) {
+            greetingEl.textContent = 'Bem vinda, Pinklover.';
+          }
           return;
         }
         renderInfluencerDetails(detailsEl, formatInfluencerDetails(influencer));
-        setMessage(messageEl, 'Dados atualizados com sucesso, Pinklover! 💗', 'success');
+        if (greetingEl) {
+          const safeName = (influencer.nome || '').trim() || 'Pinklover';
+          greetingEl.textContent = `Bem vinda, ${safeName}.`;
+        }
         loadInfluencerSales(influencer.id);
       } catch (error) {
         if (error.status === 401) {
           logout();
           return;
         }
-        setMessage(messageEl, error.message || 'Nao foi possivel carregar os dados.', 'error');
+        renderInfluencerStatus(detailsEl, error.message || 'Nao foi possivel carregar os dados.');
+        if (greetingEl) {
+          greetingEl.textContent = 'Bem vinda, Pinklover.';
+        }
       }
     };
 

--- a/public/style.css
+++ b/public/style.css
@@ -40,6 +40,18 @@ body {
   line-height: 1.6;
 }
 
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .container {
   width: min(100%, 960px);
   margin: 0 auto;
@@ -254,71 +266,80 @@ button.secondary-button:focus {
 }
 
 .message {
-  min-height: 52px;
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(228, 68, 122, 0.25);
-  background: rgba(251, 211, 219, 0.45);
-  padding: 16px 18px;
+  min-height: 44px;
+  border-radius: 16px;
+  border: 1px solid rgba(228, 68, 122, 0.18);
+  background: rgba(255, 255, 255, 0.8);
+  padding: 14px 18px;
   font-size: 0.95rem;
   color: var(--text-secondary);
-  transition: background var(--transition), border var(--transition), color var(--transition);
+  box-shadow: 0 14px 30px rgba(228, 68, 122, 0.12);
+  transition: background var(--transition), border var(--transition), color var(--transition), box-shadow var(--transition);
 }
 
 .message[data-type='success'] {
-  background: rgba(52, 211, 153, 0.15);
-  border-color: rgba(16, 185, 129, 0.35);
+  background: linear-gradient(135deg, rgba(52, 211, 153, 0.12), rgba(255, 255, 255, 0.92));
+  border-color: rgba(16, 185, 129, 0.28);
   color: #0f5132;
+  box-shadow: 0 18px 40px rgba(16, 185, 129, 0.18);
 }
 
 .message[data-type='error'] {
-  background: rgba(248, 113, 113, 0.18);
-  border-color: rgba(220, 38, 38, 0.4);
+  background: linear-gradient(135deg, rgba(248, 113, 113, 0.16), rgba(255, 255, 255, 0.95));
+  border-color: rgba(220, 38, 38, 0.32);
   color: #7f1d1d;
+  box-shadow: 0 18px 40px rgba(220, 38, 38, 0.15);
 }
 
 .message[data-type='info'] {
-  background: rgba(79, 195, 247, 0.15);
-  border-color: rgba(14, 165, 233, 0.4);
+  background: linear-gradient(135deg, rgba(79, 195, 247, 0.15), rgba(255, 255, 255, 0.94));
+  border-color: rgba(14, 165, 233, 0.32);
   color: #0b5c7a;
+  box-shadow: 0 18px 40px rgba(14, 165, 233, 0.16);
 }
 
 .table-wrapper {
   width: 100%;
-  overflow-x: auto;
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(228, 68, 122, 0.18);
-  background: #fff;
-  box-shadow: inset 0 0 0 1px rgba(251, 211, 219, 0.4);
+  overflow: hidden;
+  border-radius: 24px;
+  border: 1px solid rgba(228, 68, 122, 0.16);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 20px 44px rgba(228, 68, 122, 0.16);
 }
 
 table {
   width: 100%;
   border-collapse: collapse;
-  min-width: 560px;
+  min-width: 0;
 }
 
 table thead tr {
-  background: linear-gradient(135deg, rgba(228, 68, 122, 0.95), rgba(240, 121, 153, 0.9));
-  color: #fff;
+  background: linear-gradient(135deg, rgba(255, 233, 245, 0.92), rgba(255, 255, 255, 0.98));
+  color: var(--text-primary);
 }
 
 table th,
 table td {
-  padding: 14px 16px;
+  padding: 16px 18px;
   text-align: left;
   font-size: 0.95rem;
 }
 
-table tbody tr:nth-child(even) {
-  background: rgba(251, 211, 219, 0.55);
+table thead th {
+  font-weight: 600;
 }
 
-table tbody tr:nth-child(odd) {
-  background: rgba(255, 255, 255, 0.92);
+table tbody tr {
+  background: transparent;
+  transition: background var(--transition);
+}
+
+table tbody tr + tr {
+  border-top: 1px solid rgba(228, 68, 122, 0.16);
 }
 
 table tbody tr:hover {
-  background: rgba(240, 121, 153, 0.18);
+  background: rgba(255, 233, 245, 0.35);
 }
 
 table tbody td:last-child {
@@ -326,21 +347,375 @@ table tbody td:last-child {
 }
 
 .summary {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
-  padding: 16px;
-  border-radius: var(--radius-md);
-  background: rgba(251, 211, 219, 0.6);
-  border: 1px solid rgba(228, 68, 122, 0.22);
-  font-weight: 600;
-  color: var(--text-primary);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+  padding: 0;
+  margin: 0;
+  background: none;
+  border: none;
+  box-shadow: none;
 }
 
-.summary span {
+.summary:empty {
+  display: none;
+}
+
+.summary-item {
   display: flex;
   align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(228, 68, 122, 0.2);
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.96), rgba(251, 211, 219, 0.88));
+  box-shadow: 0 14px 32px rgba(228, 68, 122, 0.12);
+}
+
+.summary-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(228, 68, 122, 0.22), rgba(228, 68, 122, 0.38));
+  display: grid;
+  place-items: center;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+}
+
+.summary-icon::before {
+  content: '';
+  width: 26px;
+  height: 26px;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+}
+
+.summary-icon--orders::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23ffffff' viewBox='0 0 24 24'%3E%3Cpath d='M7 7V6a5 5 0 0 1 10 0v1h3a1 1 0 0 1 .99 1.14l-1.5 10A2 2 0 0 1 17.52 20H6.48a2 2 0 0 1-1.97-1.86l-1.5-10A1 1 0 0 1 4 7h3zm2-1a3 3 0 0 1 6 0v1H9zm9.03 3H5.97l1.29 8.58a1 1 0 0 0 .99.84h9.5a1 1 0 0 0 .99-.84z'/%3E%3C/svg%3E");
+}
+
+.summary-icon--revenue::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23ffffff' viewBox='0 0 24 24'%3E%3Cpath d='M12 3c3.866 0 7 1.567 7 3.5S15.866 10 12 10s-7-1.567-7-3.5S8.134 3 12 3zm0 9c2.89 0 5.478-.86 6.734-2.165.176.29.266.6.266.915C19 12.433 15.866 14 12 14s-7-1.567-7-3.5c0-.315.09-.625.266-.915C6.522 11.14 9.11 12 12 12zm0 4c2.89 0 5.478-.86 6.734-2.165.176.29.266.6.266.915C19 16.433 15.866 18 12 18s-7-1.567-7-3.5c0-.315.09-.625.266-.915C6.522 15.14 9.11 16 12 16z'/%3E%3C/svg%3E");
+}
+
+.summary-icon--commission::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23ffffff' viewBox='0 0 24 24'%3E%3Cpath d='M12 3.25l2.146 4.35 4.804.7-3.475 3.387.82 4.786L12 14.77l-4.295 2.703.82-4.786-3.475-3.388 4.804-.7z'/%3E%3C/svg%3E");
+}
+
+.summary-icon--info::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23ffffff' viewBox='0 0 24 24'%3E%3Cpath d='M12 2a10 10 0 1 0 .001 20.001A10 10 0 0 0 12 2zm0 4a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5zm1.5 11.5h-3a1 1 0 0 1 0-2h.5v-3h-.5a1 1 0 1 1 0-2h2a1 1 0 0 1 1 1v4h.5a1 1 0 0 1 0 2z'/%3E%3C/svg%3E");
+}
+
+.summary-content {
+  display: grid;
+  gap: 4px;
+}
+
+.summary-label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--pink-strong);
+  font-weight: 700;
+}
+
+.summary-value {
+  font-size: clamp(1.45rem, 2.8vw, 1.75rem);
+  font-weight: 700;
+  color: var(--pink-strong);
+}
+
+.summary-helper {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.sales-summary-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.sales-summary-wrapper .message {
+  margin: 0;
+}
+
+/* Influencer panel */
+body[data-page='influencer'] {
+  background: linear-gradient(180deg, #ffecf6 0%, #ffffff 65%);
+  padding: clamp(32px, 7vw, 88px) clamp(18px, 6vw, 48px);
+}
+
+body[data-page='influencer'] .container {
+  width: min(100%, 900px);
+  gap: clamp(28px, 5vw, 40px);
+}
+
+body[data-page='influencer'] header.page-hero {
+  display: grid;
+  justify-items: center;
+  gap: 12px;
+  padding: clamp(30px, 7vw, 44px);
+  border-radius: 40px;
+  background: linear-gradient(135deg, #ff6ea8 0%, #ffc6e0 100%);
+  color: #fff;
+  box-shadow: 0 30px 60px rgba(255, 122, 169, 0.28);
+  text-align: center;
+}
+
+body[data-page='influencer'] header.page-hero h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 2.7rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+body[data-page='influencer'] .card {
+  background: #ffffff;
+  border: 1px solid rgba(255, 177, 204, 0.45);
+  border-radius: 36px;
+  padding: clamp(28px, 6vw, 44px);
+  box-shadow: 0 28px 56px rgba(255, 143, 181, 0.18);
+}
+
+body[data-page='influencer'] .influencer-layout {
+  grid-template-columns: 1fr;
+}
+
+body[data-page='influencer'] .influencer-details-card {
+  gap: clamp(12px, 3vw, 18px);
+}
+
+body[data-page='influencer'] .influencer-details-card .message {
+  justify-self: start;
+}
+
+body[data-page='influencer'] .influencer-details-card .info-grid {
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+
+body[data-page='influencer'] .influencer-details-card .info-item {
+  padding: 0;
+  border-radius: 0;
+  border: none;
+  background: transparent;
+  box-shadow: none;
+}
+
+body[data-page='influencer'] .influencer-details-card .info-item[data-field='link'] .detail-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+body[data-page='influencer']
+  .influencer-details-card
+  .info-item:not([data-field='nome']):not([data-field='cupom']):not([data-field='link']) {
+  display: none !important;
+}
+
+body[data-page='influencer'] .influencer-details-card .info-label {
+  font-size: 1rem;
+  letter-spacing: normal;
+  text-transform: none;
+  color: rgba(102, 47, 73, 0.92);
+}
+
+body[data-page='influencer'] .influencer-details-card .info-value,
+body[data-page='influencer'] .influencer-details-card .info-value a {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--pink-strong);
+}
+
+body[data-page='influencer'] .influencer-details-card .info-status {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 500;
+  color: rgba(102, 47, 73, 0.82);
+}
+
+body[data-page='influencer'] .influencer-details-card .card-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 12px;
+}
+
+body[data-page='influencer'] .button-logout {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(255, 210, 230, 0.95));
+  color: #e4447a;
+  border: 1px solid rgba(228, 68, 122, 0.28);
+  border-radius: 999px;
+  padding: 12px 28px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 20px 36px rgba(228, 68, 122, 0.14);
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+body[data-page='influencer'] .button-logout:hover,
+body[data-page='influencer'] .button-logout:focus {
+  transform: translateY(-1px);
+  background: linear-gradient(135deg, rgba(255, 214, 233, 0.98), rgba(255, 255, 255, 0.98));
+  box-shadow: 0 26px 48px rgba(228, 68, 122, 0.22);
+  outline: none;
+}
+
+body[data-page='influencer'] .influencer-history-card {
+  gap: clamp(16px, 3vw, 24px);
+}
+
+body[data-page='influencer'] .sales-summary-wrapper {
+  gap: 22px;
+}
+
+body[data-page='influencer'] .sales-summary-inline {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+body[data-page='influencer'] .sales-summary-inline:empty {
+  display: none;
+}
+
+body[data-page='influencer'] .sales-summary-metric {
+  display: grid;
   gap: 6px;
+  padding: 18px 20px;
+  border-radius: 24px;
+  border: 1px solid rgba(255, 177, 204, 0.35);
+  background: linear-gradient(135deg, rgba(255, 241, 248, 0.96), rgba(255, 255, 255, 0.98));
+  box-shadow: 0 22px 42px rgba(255, 143, 181, 0.16);
+}
+
+body[data-page='influencer'] .sales-summary-metric span {
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(228, 68, 122, 0.85);
+}
+
+body[data-page='influencer'] .sales-summary-metric strong {
+  font-size: clamp(1.28rem, 3vw, 1.52rem);
+  font-weight: 700;
+  color: #ff418f;
+}
+
+body[data-page='influencer'] .sales-summary-wrapper .message {
+  margin: 0;
+}
+
+body[data-page='influencer'] .message {
+  border-radius: 20px;
+  border: 1px solid rgba(16, 185, 129, 0.18);
+  background: linear-gradient(135deg, rgba(236, 253, 245, 0.9), rgba(255, 255, 255, 0.95));
+  box-shadow: 0 20px 38px rgba(16, 185, 129, 0.14);
+  color: #0f5132;
+}
+
+body[data-page='influencer'] .message[data-type='info'] {
+  border-color: rgba(14, 165, 233, 0.18);
+  box-shadow: 0 20px 38px rgba(14, 165, 233, 0.12);
+  color: #0b5c7a;
+  background: linear-gradient(135deg, rgba(219, 242, 255, 0.92), rgba(255, 255, 255, 0.95));
+}
+
+body[data-page='influencer'] .message[data-type='error'] {
+  border-color: rgba(220, 38, 38, 0.24);
+  box-shadow: 0 20px 38px rgba(220, 38, 38, 0.12);
+  color: #7f1d1d;
+  background: linear-gradient(135deg, rgba(254, 226, 226, 0.92), rgba(255, 255, 255, 0.95));
+}
+
+body[data-page='influencer'] .influencer-summary {
+  display: block;
+}
+
+body[data-page='influencer'] .influencer-summary:empty {
+  display: none;
+}
+
+body[data-page='influencer'] .influencer-summary-card {
+  padding: 26px 28px;
+  border-radius: 28px;
+  border: 1px solid rgba(255, 177, 204, 0.45);
+  background: linear-gradient(135deg, rgba(255, 241, 248, 0.96), rgba(255, 255, 255, 0.98));
+  box-shadow: 0 26px 52px rgba(255, 143, 181, 0.14);
+  display: grid;
+  gap: 20px;
+}
+
+body[data-page='influencer'] .influencer-summary-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+}
+
+body[data-page='influencer'] .influencer-summary-item {
+  display: grid;
+  gap: 6px;
+  padding: 18px 20px;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(255, 177, 204, 0.32);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+}
+
+body[data-page='influencer'] .influencer-summary-item strong {
+  font-size: clamp(1.32rem, 3.2vw, 1.56rem);
+  color: #ff418f;
+}
+
+body[data-page='influencer'] .influencer-summary-label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(255, 78, 146, 0.85);
+}
+
+body[data-page='influencer'] .influencer-summary-helper {
+  font-size: 0.88rem;
+  color: rgba(102, 47, 73, 0.78);
+}
+
+body[data-page='influencer'] .influencer-summary-footer {
+  margin: 0;
+  font-size: 0.92rem;
+  font-weight: 500;
+  color: rgba(102, 47, 73, 0.9);
+}
+
+body[data-page='influencer'] .table-wrapper {
+  border-radius: 28px;
+  border: 1px solid rgba(255, 177, 204, 0.4);
+  box-shadow: 0 26px 52px rgba(255, 143, 181, 0.14);
+  background: rgba(255, 255, 255, 0.98);
+}
+
+body[data-page='influencer'] table thead tr {
+  background: linear-gradient(135deg, rgba(255, 214, 233, 0.85), rgba(255, 246, 252, 0.95));
+  color: rgba(102, 47, 73, 0.92);
+}
+
+body[data-page='influencer'] table tbody tr:nth-child(even) {
+  background: rgba(255, 245, 251, 0.8);
+}
+
+body[data-page='influencer'] table tbody tr:hover {
+  background: rgba(255, 235, 244, 0.9);
+}
+
+@media (min-width: 1040px) {
+  .dashboard-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .influencers-list {
@@ -393,6 +768,289 @@ table tbody td:last-child {
 .details p {
   margin: 0;
   color: var(--text-secondary);
+}
+
+.message:empty {
+  display: none;
+}
+
+.dashboard-grid {
+  display: grid;
+  gap: clamp(24px, 4vw, 32px);
+}
+
+.card-heading {
+  display: grid;
+  gap: 8px;
+  text-align: center;
+}
+
+.card-subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.info-item {
+  display: grid;
+  gap: 8px;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(251, 211, 219, 0.82));
+  border: 1px solid rgba(228, 68, 122, 0.2);
+  box-shadow: 0 16px 32px rgba(228, 68, 122, 0.12);
+}
+
+.info-label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--pink-strong);
+}
+
+.info-value {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.info-value.detail-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.detail-link {
+  color: var(--pink-strong);
+  font-weight: 600;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(228, 68, 122, 0.4);
+  padding-bottom: 2px;
+  transition: color var(--transition), border-color var(--transition);
+}
+
+.detail-link:hover,
+.detail-link:focus {
+  color: var(--pink-medium);
+  border-color: rgba(240, 121, 153, 0.6);
+  outline: none;
+}
+
+button.copy-button {
+  background: rgba(228, 68, 122, 0.14);
+  color: var(--pink-strong);
+  border: 1px solid rgba(228, 68, 122, 0.28);
+  box-shadow: none;
+  font-size: 0.9rem;
+  padding: 8px 18px;
+  border-radius: 999px;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+button.copy-button:hover,
+button.copy-button:focus {
+  transform: translateY(-1px);
+  background: rgba(228, 68, 122, 0.22);
+  box-shadow: 0 10px 20px rgba(228, 68, 122, 0.18);
+  outline: none;
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: clamp(16px, 6vw, 32px) clamp(14px, 5vw, 28px);
+  }
+
+  header {
+    text-align: left;
+    justify-items: stretch;
+  }
+
+  header button {
+    justify-self: stretch;
+    width: 100%;
+  }
+
+  .card {
+    padding: clamp(20px, 6vw, 28px);
+  }
+
+  body[data-page='influencer'] header.page-hero {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  body[data-page='influencer'] header.page-hero button {
+    width: 100%;
+    align-self: stretch;
+  }
+
+  body[data-page='influencer'] .card {
+    padding: clamp(22px, 7vw, 32px);
+  }
+
+  body[data-page='influencer'] .influencer-details-card .card-actions {
+    justify-content: stretch;
+  }
+
+  body[data-page='influencer'] .influencer-details-card .button-logout {
+    width: 100%;
+  }
+
+  body[data-page='influencer'] .influencer-summary-item + .influencer-summary-item {
+    border-left: none;
+    border-top: 1px solid rgba(228, 68, 122, 0.18);
+    padding-left: 0;
+    margin-left: 0;
+    padding-top: 16px;
+    margin-top: 8px;
+  }
+
+  .summary {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .summary-item {
+    padding: 16px 18px;
+  }
+
+  .summary-icon {
+    width: 48px;
+    height: 48px;
+  }
+
+  .summary-icon::before {
+    width: 24px;
+    height: 24px;
+  }
+
+  .summary-value {
+    font-size: 1.35rem;
+  }
+
+  .info-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .sales-summary-wrapper {
+    margin-bottom: 12px;
+  }
+
+  .summary {
+    gap: 14px;
+  }
+
+  .summary-item {
+    padding: 14px 16px;
+  }
+
+  .summary-value {
+    font-size: 1.28rem;
+  }
+
+  .summary-helper {
+    font-size: 0.85rem;
+  }
+
+  body[data-page='influencer'] .influencer-summary-card {
+    padding: 20px 22px;
+  }
+
+  body[data-page='influencer'] .influencer-summary-metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .table-wrapper {
+    overflow: visible;
+    border: none;
+    background: transparent;
+    box-shadow: none;
+    padding: 0;
+  }
+
+  table {
+    min-width: 0;
+    border: none;
+  }
+
+  table thead {
+    display: none;
+  }
+
+  table tbody {
+    display: grid;
+    gap: 14px;
+  }
+
+  table tbody tr {
+    display: grid;
+    gap: 10px;
+    padding: 16px 18px;
+    border-radius: var(--radius-md);
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(251, 211, 219, 0.9));
+    box-shadow: 0 14px 30px rgba(228, 68, 122, 0.14);
+  }
+
+  table tbody tr:nth-child(even),
+  table tbody tr:nth-child(odd),
+  table tbody tr:hover {
+    background: none;
+  }
+
+  table tbody td {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 0;
+    border: none;
+    font-size: 0.94rem;
+    color: var(--text-secondary);
+  }
+
+  table tbody td::before {
+    content: attr(data-label);
+    font-weight: 700;
+    color: var(--text-primary);
+    font-size: 0.92rem;
+  }
+
+  table tbody td:last-child {
+    white-space: normal;
+  }
+
+  .message {
+    font-size: 0.9rem;
+  }
+}
+
+button.copy-button.copied {
+  background: rgba(52, 211, 153, 0.18);
+  border-color: rgba(16, 185, 129, 0.32);
+  color: #0f5132;
+}
+
+button.copy-button.error {
+  background: rgba(248, 113, 113, 0.16);
+  border-color: rgba(220, 38, 38, 0.32);
+  color: #7f1d1d;
+}
+
+@media (max-width: 600px) {
+  .info-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 900px) {
@@ -453,10 +1111,6 @@ table tbody td:last-child {
 
 body[data-page='master-create'] #createInfluencerForm[data-mode='edit'] .credentials-group {
   display: none;
-}
-
-.summary strong {
-  color: var(--pink-strong);
 }
 
 /* Login page adjustments */


### PR DESCRIPTION
## Summary
- add a logout control and copy action to the influencer detail card while keeping only the requested fields visible
- compute sales totals and render a summary of orders and commissions before the history table with the updated column set
- refresh the influencer styles to accommodate the copy button, logout control, and new summary metrics across desktop and mobile

## Testing
- npm test *(fails: better-sqlite3 native module has an invalid ELF header in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e695ba44948323ba61fc4061d4a49f