### PR TITLE
Allow optional influencer import fields

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -509,6 +509,7 @@
 
   const validateInfluencerPayload = (form, payload, options = {}) => {
     const requireCredentials = options.requireCredentials ?? true;
+    const requirePrimaryFields = options.requirePrimaryFields ?? true;
     const errors = [];
     const mark = (name, condition, message) => {
       const field = form?.elements?.[name];
@@ -524,8 +525,13 @@
     const estado = (payload.estado || '').trim();
     const commissionPercent = payload.commissionPercent;
 
-    mark('nome', Boolean(nome), 'Informe o nome.');
-    mark('instagram', Boolean(instagram), 'Informe o Instagram.');
+    if (requirePrimaryFields) {
+      mark('nome', Boolean(nome), 'Informe o nome.');
+      mark('instagram', Boolean(instagram), 'Informe o Instagram.');
+    } else {
+      mark('nome', true);
+      mark('instagram', true);
+    }
 
     mark('cpf', isValidCPF(payload.cpf), 'CPF invalido.');
     mark('email', !email || validators.email(email), 'Email invalido.');
@@ -868,6 +874,8 @@
     const messageEl = document.getElementById('masterMessage');
     const cancelBtn = document.getElementById('cancelEditButton');
 
+    const allowOptionalFields = (document.body?.dataset?.allowOptionalFields || '').toLowerCase() === 'true';
+
     const credentialsBox = document.getElementById('generatedCredentials');
     const credentialCodeField = document.getElementById('generatedSignatureCode');
     const credentialEmailField = document.getElementById('generatedLoginEmail');
@@ -893,7 +901,11 @@
     let currentContractDocument = null;
 
     if (loginEmailInput) {
-      loginEmailInput.setAttribute('readonly', '');
+      if (allowOptionalFields) {
+        loginEmailInput.removeAttribute('readonly');
+      } else {
+        loginEmailInput.setAttribute('readonly', '');
+      }
     }
 
     const hideGeneratedCredentials = () => {
@@ -1051,12 +1063,20 @@
       syncLoginPassword();
     };
 
-    syncCredentials();
+    if (!allowOptionalFields) {
+      syncCredentials();
+    } else {
+      if (passwordInput) {
+        passwordInput.removeAttribute('readonly');
+      }
+    }
 
     resetContractRecord({ hide: true });
 
-    emailInput?.addEventListener('input', syncLoginEmail);
-    cpfInput?.addEventListener('input', syncLoginPassword);
+    if (!allowOptionalFields) {
+      emailInput?.addEventListener('input', syncLoginEmail);
+      cpfInput?.addEventListener('input', syncLoginPassword);
+    }
 
     let editingId = null;
 
@@ -1080,10 +1100,16 @@
         form.querySelectorAll('[aria-invalid="true"]').forEach((el) => el.removeAttribute('aria-invalid'));
       }
       if (passwordInput) {
-        passwordInput.placeholder = 'Senha gerada automaticamente a partir do CPF';
-        passwordInput.setAttribute('required', '');
-        const cpfDigits = digitOnly(cpfInput?.value || '');
-        passwordInput.value = cpfDigits;
+        if (allowOptionalFields) {
+          passwordInput.placeholder = 'Defina uma senha provisória';
+          passwordInput.removeAttribute('required');
+          passwordInput.value = '';
+        } else {
+          passwordInput.placeholder = 'Senha gerada automaticamente a partir do CPF';
+          passwordInput.setAttribute('required', '');
+          const cpfDigits = digitOnly(cpfInput?.value || '');
+          passwordInput.value = cpfDigits;
+        }
       }
       if (signatureCodeInput) {
         signatureCodeInput.placeholder = 'Gerado automaticamente após o cadastro';
@@ -1178,9 +1204,12 @@
       const normalized = normalizeInfluencerForSubmit(payload);
       const currentEditId = editingId ?? Number(form?.dataset?.editId || 0);
       editingId = currentEditId || null;
-      const requireCredentials = !currentEditId;
+      const requireCredentials = !currentEditId && !allowOptionalFields;
 
-      const validation = validateInfluencerPayload(form, normalized, { requireCredentials });
+      const validation = validateInfluencerPayload(form, normalized, {
+        requireCredentials,
+        requirePrimaryFields: !allowOptionalFields
+      });
       if (!validation.isValid) {
         setMessage(messageEl, validation.errors.join(' '), 'error');
         focusFirstInvalidField(form);
@@ -1203,13 +1232,18 @@
           setMessage(messageEl, 'Influenciadora atualizada com sucesso.', 'success');
           resetForm({ clearMessage: false });
         } else {
-          setMessage(
-            messageEl,
-            'Influenciadora cadastrada com sucesso. Compartilhe as credenciais geradas abaixo.',
-            'success'
-          );
+          const successMessage = allowOptionalFields
+            ? 'Influenciadora importada com sucesso. Ajuste os dados quando necessário.'
+            : 'Influenciadora cadastrada com sucesso. Compartilhe as credenciais geradas abaixo.';
+          setMessage(messageEl, successMessage, 'success');
           resetForm({ clearMessage: false, preserveSummary: true });
-          showGeneratedCredentials(response || {});
+          if (!allowOptionalFields) {
+            showGeneratedCredentials(response || {});
+          } else if (response && (response.codigo_assinatura || response.login_email || response.senha_provisoria)) {
+            showGeneratedCredentials(response);
+          } else {
+            hideGeneratedCredentials();
+          }
         }
       } catch (error) {
         if (error.status === 401) {

--- a/public/master-import-influencers.html
+++ b/public/master-import-influencers.html
@@ -1,0 +1,88 @@
+﻿<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Importar influenciadoras | Sistema Influenciadoras</title>
+    <link rel="stylesheet" href="style.css" />
+    <script defer src="main.js"></script>
+  </head>
+  <body data-page="master-create" data-allow-optional-fields="true">
+    <div class="container">
+      <header>
+        <h1>Importar influenciadoras</h1>
+        <p>Cadastre rapidamente novas influenciadoras e ajuste os dados depois, se necessário.</p>
+        <button type="button" data-action="logout">Sair</button>
+      </header>
+
+      <section class="card">
+        <div class="link-grid" style="margin-bottom:16px;">
+          <a class="link-card" href="master-consult.html">Consulta</a>
+          <a class="link-card" href="master-list.html">Lista cadastrada</a>
+          <a class="link-card" href="master-sales.html">Registrar venda</a>
+          <a class="link-card" href="master-create.html">Cadastro completo</a>
+        </div>
+
+        <form id="createInfluencerForm" data-form="create-influencer">
+          <span class="section-title">Informacoes basicas (todas opcionais)</span>
+          <div class="form-grid compact">
+            <label>Nome<input name="nome" type="text" /></label>
+            <label>Instagram<input name="instagram" type="text" placeholder="@perfil" /></label>
+            <label>CPF<input name="cpf" type="text" placeholder="000.000.000-00" /></label>
+            <label>Email<input name="email" type="email" /></label>
+            <label>Contato<input name="contato" type="text" placeholder="(00) 00000-0000" /></label>
+            <label>Cupom<input name="cupom" type="text" /></label>
+            <label>Comissao (%)<input name="commissionPercent" type="number" min="0" max="100" step="0.01" /></label>
+          </div>
+
+          <span class="section-title">Endereco (opcional)</span>
+          <div class="form-grid compact">
+            <label>CEP<input name="cep" type="text" placeholder="00000-000" /></label>
+            <label>Numero<input name="numero" type="text" /></label>
+            <label>Complemento<input name="complemento" type="text" /></label>
+            <label>Logradouro<input name="logradouro" type="text" /></label>
+            <label>Bairro<input name="bairro" type="text" /></label>
+            <label>Cidade<input name="cidade" type="text" /></label>
+            <label>Estado<input name="estado" type="text" maxlength="2" /></label>
+          </div>
+
+          <div class="credentials-group">
+            <span class="section-title">Credenciais de acesso (opcional)</span>
+            <p class="credentials-hint">Preencha apenas se desejar gerar acesso imediato. Caso contrário, você poderá completar depois.</p>
+            <label>Email de acesso<input name="loginEmail" type="email" placeholder="login@influencer.com" /></label>
+            <label>Senha de acesso<input name="loginPassword" type="password" placeholder="Defina uma senha provisória" minlength="6" /></label>
+            <label>Código do contrato<input name="signatureCode" type="text" placeholder="Gerado automaticamente após o cadastro" readonly /></label>
+          </div>
+
+          <section id="generatedCredentials" class="credentials-summary" hidden>
+            <span class="section-title">Compartilhe com a influenciadora</span>
+            <p class="credentials-summary__description">
+              Entregue estes dados de acesso e o código de assinatura para que ela conclua o aceite do termo.
+            </p>
+            <div class="form-grid compact">
+              <label>Código de assinatura<input id="generatedSignatureCode" type="text" readonly /></label>
+              <label>Email de acesso<input id="generatedLoginEmail" type="text" readonly /></label>
+              <label>Senha provisória<input id="generatedPassword" type="text" readonly /></label>
+            </div>
+          </section>
+
+          <section id="contractRecordSection" class="contract-summary" hidden>
+            <span class="section-title">Contrato assinado</span>
+            <p id="contractRecordMessage" class="note"></p>
+            <div id="contractRecordDetails" class="contract-summary__details"></div>
+            <div class="contract-summary__actions">
+              <button type="button" id="viewContractRecordButton" disabled>Visualizar contrato assinado</button>
+              <button type="button" id="downloadContractRecordButton" class="secondary-button" disabled>Baixar contrato</button>
+            </div>
+          </section>
+
+          <div class="button-row">
+            <button type="submit">Importar</button>
+            <button type="button" class="secondary-button" id="cancelEditButton">Cancelar edicao</button>
+          </div>
+        </form>
+        <div id="masterMessage" class="message" aria-live="polite"></div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/public/master.html
+++ b/public/master.html
@@ -19,6 +19,7 @@
         <h2>Acessos rapidos</h2>
         <div class="link-grid">
           <a class="link-card" href="master-create.html">Cadastrar influenciadora</a>
+          <a class="link-card" href="master-import-influencers.html">Importar influenciadoras</a>
           <a class="link-card" href="master-consult.html">Consulta de influenciadoras</a>
           <a class="link-card" href="master-list.html">Influenciadoras cadastradas</a>
           <a class="link-card" href="master-sales.html">Registrar venda</a>


### PR DESCRIPTION
## Summary
- add a master import page for influencers with all fields optional and a quick link from the dashboard
- update the master form script to support optional field flows, skipping client-side requirements when enabled

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e9ef301a30832382b58f6807095405