### PR TITLE
Allow partial influencer imports

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -509,6 +509,7 @@
 
   const validateInfluencerPayload = (form, payload, options = {}) => {
     const requireCredentials = options.requireCredentials ?? true;
+    const requirePrimaryFields = options.requirePrimaryFields ?? true;
     const errors = [];
     const mark = (name, condition, message) => {
       const field = form?.elements?.[name];
@@ -524,8 +525,13 @@
     const estado = (payload.estado || '').trim();
     const commissionPercent = payload.commissionPercent;
 
-    mark('nome', Boolean(nome), 'Informe o nome.');
-    mark('instagram', Boolean(instagram), 'Informe o Instagram.');
+    if (requirePrimaryFields) {
+      mark('nome', Boolean(nome), 'Informe o nome.');
+      mark('instagram', Boolean(instagram), 'Informe o Instagram.');
+    } else {
+      mark('nome', true);
+      mark('instagram', true);
+    }
 
     mark('cpf', isValidCPF(payload.cpf), 'CPF invalido.');
     mark('email', !email || validators.email(email), 'Email invalido.');
@@ -868,6 +874,8 @@
     const messageEl = document.getElementById('masterMessage');
     const cancelBtn = document.getElementById('cancelEditButton');
 
+    const allowOptionalFields = (document.body?.dataset?.allowOptionalFields || '').toLowerCase() === 'true';
+
     const credentialsBox = document.getElementById('generatedCredentials');
     const credentialCodeField = document.getElementById('generatedSignatureCode');
     const credentialEmailField = document.getElementById('generatedLoginEmail');
@@ -893,7 +901,11 @@
     let currentContractDocument = null;
 
     if (loginEmailInput) {
-      loginEmailInput.setAttribute('readonly', '');
+      if (allowOptionalFields) {
+        loginEmailInput.removeAttribute('readonly');
+      } else {
+        loginEmailInput.setAttribute('readonly', '');
+      }
     }
 
     const hideGeneratedCredentials = () => {
@@ -1051,12 +1063,20 @@
       syncLoginPassword();
     };
 
-    syncCredentials();
+    if (!allowOptionalFields) {
+      syncCredentials();
+    } else {
+      if (passwordInput) {
+        passwordInput.removeAttribute('readonly');
+      }
+    }
 
     resetContractRecord({ hide: true });
 
-    emailInput?.addEventListener('input', syncLoginEmail);
-    cpfInput?.addEventListener('input', syncLoginPassword);
+    if (!allowOptionalFields) {
+      emailInput?.addEventListener('input', syncLoginEmail);
+      cpfInput?.addEventListener('input', syncLoginPassword);
+    }
 
     let editingId = null;
 
@@ -1080,10 +1100,16 @@
         form.querySelectorAll('[aria-invalid="true"]').forEach((el) => el.removeAttribute('aria-invalid'));
       }
       if (passwordInput) {
-        passwordInput.placeholder = 'Senha gerada automaticamente a partir do CPF';
-        passwordInput.setAttribute('required', '');
-        const cpfDigits = digitOnly(cpfInput?.value || '');
-        passwordInput.value = cpfDigits;
+        if (allowOptionalFields) {
+          passwordInput.placeholder = 'Defina uma senha provisória';
+          passwordInput.removeAttribute('required');
+          passwordInput.value = '';
+        } else {
+          passwordInput.placeholder = 'Senha gerada automaticamente a partir do CPF';
+          passwordInput.setAttribute('required', '');
+          const cpfDigits = digitOnly(cpfInput?.value || '');
+          passwordInput.value = cpfDigits;
+        }
       }
       if (signatureCodeInput) {
         signatureCodeInput.placeholder = 'Gerado automaticamente após o cadastro';
@@ -1178,9 +1204,12 @@
       const normalized = normalizeInfluencerForSubmit(payload);
       const currentEditId = editingId ?? Number(form?.dataset?.editId || 0);
       editingId = currentEditId || null;
-      const requireCredentials = !currentEditId;
+      const requireCredentials = !currentEditId && !allowOptionalFields;
 
-      const validation = validateInfluencerPayload(form, normalized, { requireCredentials });
+      const validation = validateInfluencerPayload(form, normalized, {
+        requireCredentials,
+        requirePrimaryFields: !allowOptionalFields
+      });
       if (!validation.isValid) {
         setMessage(messageEl, validation.errors.join(' '), 'error');
         focusFirstInvalidField(form);
@@ -1191,7 +1220,8 @@
         ...normalized,
         commissionPercent: normalized.commissionPercent !== '' ? Number(normalized.commissionPercent) : undefined,
         loginEmail: normalized.loginEmail || undefined,
-        loginPassword: normalized.loginPassword || undefined
+        loginPassword: normalized.loginPassword || undefined,
+        optionalImport: allowOptionalFields && !currentEditId ? true : undefined
       };
 
       const endpoint = currentEditId ? `/influenciadora/${currentEditId}` : '/influenciadora';
@@ -1203,13 +1233,18 @@
           setMessage(messageEl, 'Influenciadora atualizada com sucesso.', 'success');
           resetForm({ clearMessage: false });
         } else {
-          setMessage(
-            messageEl,
-            'Influenciadora cadastrada com sucesso. Compartilhe as credenciais geradas abaixo.',
-            'success'
-          );
+          const successMessage = allowOptionalFields
+            ? 'Influenciadora importada com sucesso. Ajuste os dados quando necessário.'
+            : 'Influenciadora cadastrada com sucesso. Compartilhe as credenciais geradas abaixo.';
+          setMessage(messageEl, successMessage, 'success');
           resetForm({ clearMessage: false, preserveSummary: true });
-          showGeneratedCredentials(response || {});
+          if (!allowOptionalFields) {
+            showGeneratedCredentials(response || {});
+          } else if (response && (response.codigo_assinatura || response.login_email || response.senha_provisoria)) {
+            showGeneratedCredentials(response);
+          } else {
+            hideGeneratedCredentials();
+          }
         }
       } catch (error) {
         if (error.status === 401) {

--- a/public/master-import-influencers.html
+++ b/public/master-import-influencers.html
@@ -1,0 +1,88 @@
+﻿<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Importar influenciadoras | Sistema Influenciadoras</title>
+    <link rel="stylesheet" href="style.css" />
+    <script defer src="main.js"></script>
+  </head>
+  <body data-page="master-create" data-allow-optional-fields="true">
+    <div class="container">
+      <header>
+        <h1>Importar influenciadoras</h1>
+        <p>Cadastre rapidamente novas influenciadoras e ajuste os dados depois, se necessário.</p>
+        <button type="button" data-action="logout">Sair</button>
+      </header>
+
+      <section class="card">
+        <div class="link-grid" style="margin-bottom:16px;">
+          <a class="link-card" href="master-consult.html">Consulta</a>
+          <a class="link-card" href="master-list.html">Lista cadastrada</a>
+          <a class="link-card" href="master-sales.html">Registrar venda</a>
+          <a class="link-card" href="master-create.html">Cadastro completo</a>
+        </div>
+
+        <form id="createInfluencerForm" data-form="create-influencer">
+          <span class="section-title">Informacoes basicas (todas opcionais)</span>
+          <div class="form-grid compact">
+            <label>Nome<input name="nome" type="text" /></label>
+            <label>Instagram<input name="instagram" type="text" placeholder="@perfil" /></label>
+            <label>CPF<input name="cpf" type="text" placeholder="000.000.000-00" /></label>
+            <label>Email<input name="email" type="email" /></label>
+            <label>Contato<input name="contato" type="text" placeholder="(00) 00000-0000" /></label>
+            <label>Cupom<input name="cupom" type="text" /></label>
+            <label>Comissao (%)<input name="commissionPercent" type="number" min="0" max="100" step="0.01" /></label>
+          </div>
+
+          <span class="section-title">Endereco (opcional)</span>
+          <div class="form-grid compact">
+            <label>CEP<input name="cep" type="text" placeholder="00000-000" /></label>
+            <label>Numero<input name="numero" type="text" /></label>
+            <label>Complemento<input name="complemento" type="text" /></label>
+            <label>Logradouro<input name="logradouro" type="text" /></label>
+            <label>Bairro<input name="bairro" type="text" /></label>
+            <label>Cidade<input name="cidade" type="text" /></label>
+            <label>Estado<input name="estado" type="text" maxlength="2" /></label>
+          </div>
+
+          <div class="credentials-group">
+            <span class="section-title">Credenciais de acesso (opcional)</span>
+            <p class="credentials-hint">Preencha apenas se desejar gerar acesso imediato. Caso contrário, você poderá completar depois.</p>
+            <label>Email de acesso<input name="loginEmail" type="email" placeholder="login@influencer.com" /></label>
+            <label>Senha de acesso<input name="loginPassword" type="password" placeholder="Defina uma senha provisória" minlength="6" /></label>
+            <label>Código do contrato<input name="signatureCode" type="text" placeholder="Gerado automaticamente após o cadastro" readonly /></label>
+          </div>
+
+          <section id="generatedCredentials" class="credentials-summary" hidden>
+            <span class="section-title">Compartilhe com a influenciadora</span>
+            <p class="credentials-summary__description">
+              Entregue estes dados de acesso e o código de assinatura para que ela conclua o aceite do termo.
+            </p>
+            <div class="form-grid compact">
+              <label>Código de assinatura<input id="generatedSignatureCode" type="text" readonly /></label>
+              <label>Email de acesso<input id="generatedLoginEmail" type="text" readonly /></label>
+              <label>Senha provisória<input id="generatedPassword" type="text" readonly /></label>
+            </div>
+          </section>
+
+          <section id="contractRecordSection" class="contract-summary" hidden>
+            <span class="section-title">Contrato assinado</span>
+            <p id="contractRecordMessage" class="note"></p>
+            <div id="contractRecordDetails" class="contract-summary__details"></div>
+            <div class="contract-summary__actions">
+              <button type="button" id="viewContractRecordButton" disabled>Visualizar contrato assinado</button>
+              <button type="button" id="downloadContractRecordButton" class="secondary-button" disabled>Baixar contrato</button>
+            </div>
+          </section>
+
+          <div class="button-row">
+            <button type="submit">Importar</button>
+            <button type="button" class="secondary-button" id="cancelEditButton">Cancelar edicao</button>
+          </div>
+        </form>
+        <div id="masterMessage" class="message" aria-live="polite"></div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/public/master.html
+++ b/public/master.html
@@ -19,6 +19,7 @@
         <h2>Acessos rapidos</h2>
         <div class="link-grid">
           <a class="link-card" href="master-create.html">Cadastrar influenciadora</a>
+          <a class="link-card" href="master-import-influencers.html">Importar influenciadoras</a>
           <a class="link-card" href="master-consult.html">Consulta de influenciadoras</a>
           <a class="link-card" href="master-list.html">Influenciadoras cadastradas</a>
           <a class="link-card" href="master-sales.html">Registrar venda</a>

--- a/src/server.js
+++ b/src/server.js
@@ -328,7 +328,8 @@ app.use('/api', aceiteRouter);
 
 const trimString = (value) => (typeof value === 'string' ? value.trim() : value);
 
-const normalizeInfluencerPayload = (body) => {
+const normalizeInfluencerPayload = (body, options = {}) => {
+  const allowMissingPrimary = Boolean(options.allowMissingPrimary);
   const normalized = {
     nome: trimString(body.nome),
     instagram: trimString(body.instagram),
@@ -349,8 +350,8 @@ const normalizeInfluencerPayload = (body) => {
   };
 
   const missing = [];
-  if (!normalized.nome) missing.push('nome');
-  if (!normalized.instagram) missing.push('instagram');
+  if (!normalized.nome && !allowMissingPrimary) missing.push('nome');
+  if (!normalized.instagram && !allowMissingPrimary) missing.push('instagram');
   if (missing.length) {
     return { error: { error: 'Campos obrigatorios faltando.', campos: missing } };
   }
@@ -424,10 +425,16 @@ const normalizeInfluencerPayload = (body) => {
 
   const estadoValue = normalized.estado ? normalized.estado.toUpperCase() : null;
 
+  const instagramValue = normalized.instagram
+    ? normalized.instagram.startsWith('@')
+      ? normalized.instagram
+      : `@${normalized.instagram}`
+    : null;
+
   return {
     data: {
-      nome: normalized.nome,
-      instagram: normalized.instagram.startsWith('@') ? normalized.instagram : `@${normalized.instagram}`,
+      nome: normalized.nome || null,
+      instagram: instagramValue,
       cpf: formattedCpf,
       email: normalized.email || null,
       contato: formattedContato,
@@ -782,11 +789,16 @@ const formatSaleRow = (row) => {
 };
 
 const createInfluencerTransaction = db.transaction((influencerPayload, userPayload) => {
-  const mustChange = userPayload.mustChange ?? 0;
-  const userResult = insertUserStmt.run(userPayload.email, userPayload.passwordHash, 'influencer', mustChange);
-  const userId = userResult.lastInsertRowid;
-  const influencerResult = insertInfluencerStmt.run({ ...influencerPayload, user_id: userId });
-  return { influencerId: influencerResult.lastInsertRowid, userId };
+  if (userPayload) {
+    const mustChange = userPayload.mustChange ?? 0;
+    const userResult = insertUserStmt.run(userPayload.email, userPayload.passwordHash, 'influencer', mustChange);
+    const userId = userResult.lastInsertRowid;
+    const influencerResult = insertInfluencerStmt.run({ ...influencerPayload, user_id: userId });
+    return { influencerId: influencerResult.lastInsertRowid, userId };
+  }
+
+  const influencerResult = insertInfluencerStmt.run({ ...influencerPayload, user_id: null });
+  return { influencerId: influencerResult.lastInsertRowid, userId: null };
 });
 
 const formatUserResponse = (user) => ({ id: user.id, email: user.email, role: user.role });
@@ -907,31 +919,69 @@ app.post('/login', async (req, res) => {
 });
 
 app.post('/influenciadora', authenticate, authorizeMaster, async (req, res) => {
-  const { data, error } = normalizeInfluencerPayload(req.body || {});
+  const allowPartialImport = String(req.body?.optionalImport ?? '').toLowerCase() === 'true';
+
+  const { data, error } = normalizeInfluencerPayload(req.body || {}, {
+    allowMissingPrimary: allowPartialImport
+  });
 
   if (error) {
     return res.status(400).json(error);
   }
 
+  if (allowPartialImport) {
+    const randomSuffix = crypto.randomBytes(4).toString('hex');
+    if (!data.nome) {
+      data.nome = `Importado ${randomSuffix}`;
+    }
+    if (!data.instagram) {
+      data.instagram = `@importado_${randomSuffix}`;
+    }
+  }
+
   const cpfDigits = normalizeDigits(req.body?.cpf || data?.cpf || '');
-  if (cpfDigits.length !== 11) {
-    return res.status(400).json({ error: 'Informe um CPF valido para gerar a senha provisoria.' });
+  const loginEmailInput = trimString(req.body?.loginEmail);
+  const contactEmail = data.email;
+  const loginEmail = allowPartialImport ? loginEmailInput : loginEmailInput || contactEmail;
+
+  if (!allowPartialImport) {
+    if (cpfDigits.length !== 11) {
+      return res.status(400).json({ error: 'Informe um CPF valido para gerar a senha provisoria.' });
+    }
+    if (!loginEmail || !validators.email(loginEmail)) {
+      return res.status(400).json({ error: 'Informe um email valido para acesso.' });
+    }
+  } else {
+    if (loginEmail && !validators.email(loginEmail)) {
+      return res.status(400).json({ error: 'Informe um email valido para acesso.' });
+    }
+    const hasCpf = cpfDigits.length === 11;
+    if ((loginEmail && !hasCpf) || (hasCpf && !loginEmail)) {
+      return res
+        .status(400)
+        .json({ error: 'Informe CPF e email de acesso para gerar credenciais, ou deixe ambos em branco.' });
+    }
   }
 
-  const loginEmail = trimString(req.body?.loginEmail) || data.email;
-  if (!loginEmail || !validators.email(loginEmail)) {
-    return res.status(400).json({ error: 'Informe um email valido para acesso.' });
-  }
-
-  if (findUserByEmailStmt.get(loginEmail)) {
+  if (loginEmail && findUserByEmailStmt.get(loginEmail)) {
     return res.status(409).json({ error: 'Email de login ja cadastrado.' });
   }
 
-  const provisionalPassword = cpfDigits;
-  const passwordHash = await bcrypt.hash(provisionalPassword, 10);
-  const signatureCode = String(crypto.randomInt(0, 1_000_000)).padStart(6, '0');
-  const signatureCodeHash = await bcrypt.hash(signatureCode, 10);
-  const generatedAt = new Date().toISOString();
+  const shouldCreateCredentials = Boolean(loginEmail);
+
+  let provisionalPassword = null;
+  let signatureCode = null;
+  let signatureCodeHash = null;
+  let generatedAt = null;
+  let passwordHash = null;
+
+  if (shouldCreateCredentials) {
+    provisionalPassword = cpfDigits;
+    passwordHash = await bcrypt.hash(provisionalPassword, 10);
+    signatureCode = String(crypto.randomInt(0, 1_000_000)).padStart(6, '0');
+    signatureCodeHash = await bcrypt.hash(signatureCode, 10);
+    generatedAt = new Date().toISOString();
+  }
 
   try {
     const { influencerId } = createInfluencerTransaction(
@@ -940,15 +990,18 @@ app.post('/influenciadora', authenticate, authorizeMaster, async (req, res) => {
         contract_signature_code_hash: signatureCodeHash,
         contract_signature_code_generated_at: generatedAt
       },
-      { email: loginEmail, passwordHash, mustChange: 0 }
+      shouldCreateCredentials ? { email: loginEmail, passwordHash, mustChange: 0 } : null
     );
     const influencer = findInfluencerByIdStmt.get(influencerId);
-    return res.status(201).json({
-      ...influencer,
-      login_email: loginEmail,
-      senha_provisoria: provisionalPassword,
-      codigo_assinatura: signatureCode
-    });
+    const responsePayload = {
+      ...influencer
+    };
+    if (shouldCreateCredentials) {
+      responsePayload.login_email = loginEmail;
+      responsePayload.senha_provisoria = provisionalPassword;
+      responsePayload.codigo_assinatura = signatureCode;
+    }
+    return res.status(201).json(responsePayload);
   } catch (err) {
     if (err && err.code === 'SQLITE_CONSTRAINT_UNIQUE') {
       return res.status(409).json({ error: 'Instagram ou email ja cadastrado.' });


### PR DESCRIPTION
## Summary
- send a flag from the optional import form so the API can treat the submission as a partial import
- relax influencer normalization to allow missing primary fields when flagged and generate safe placeholders for storage
- create influencers without credentials unless a valid CPF and login email are supplied

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e9ef301a30832382b58f6807095405